### PR TITLE
feat: add Execution Shield config layer (ShieldConfig + env/file loaders)

### DIFF
--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -59,6 +59,16 @@ from veronica_core.integration import (
     get_veronica_integration,
 )
 
+# Execution Shield (v0.3 -- opt-in, all features disabled by default)
+from veronica_core.shield import ShieldConfig
+from veronica_core.shield.config import (
+    SafeModeConfig,
+    BudgetConfig,
+    CircuitBreakerConfig,
+    EgressConfig,
+    SecretGuardConfig,
+)
+
 __all__ = [
     # Core
     "VeronicaState",
@@ -94,4 +104,11 @@ __all__ = [
     # Integration
     "VeronicaIntegration",
     "get_veronica_integration",
+    # Execution Shield (v0.3)
+    "ShieldConfig",
+    "SafeModeConfig",
+    "BudgetConfig",
+    "CircuitBreakerConfig",
+    "EgressConfig",
+    "SecretGuardConfig",
 ]

--- a/src/veronica_core/integration.py
+++ b/src/veronica_core/integration.py
@@ -16,6 +16,7 @@ from veronica_core.exit import VeronicaExit
 from veronica_core.backends import PersistenceBackend, JSONBackend
 from veronica_core.guards import VeronicaGuard, PermissiveGuard
 from veronica_core.clients import LLMClient, NullClient
+from veronica_core.shield.config import ShieldConfig
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class VeronicaIntegration:
         backend: Optional[PersistenceBackend] = None,
         guard: Optional[VeronicaGuard] = None,
         client: Optional[LLMClient] = None,
+        shield: Optional[ShieldConfig] = None,
     ):
         """Initialize integration layer.
 
@@ -45,6 +47,7 @@ class VeronicaIntegration:
             backend: Persistence backend (default: JSONBackend with VeronicaPersistence path)
             guard: Validation guard (default: PermissiveGuard)
             client: LLM client (optional, default: NullClient - no LLM features)
+            shield: Shield configuration (optional, default: None - no shield)
         """
         # Set up backend (backward compatible with VeronicaPersistence)
         if backend is None:
@@ -60,6 +63,9 @@ class VeronicaIntegration:
 
         # Set up LLM client (optional)
         self.client: LLMClient = client or NullClient()
+
+        # Shield configuration (opt-in, stored only -- no behavior change yet)
+        self.shield: Optional[ShieldConfig] = shield
 
         # Load state
         if self.backend:

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,0 +1,3 @@
+"""VERONICA Execution Shield."""
+from veronica_core.shield.config import ShieldConfig
+__all__ = ["ShieldConfig"]

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -1,0 +1,135 @@
+"""Shield configuration models for VERONICA Execution Shield.
+
+Uses stdlib dataclasses only (zero external dependencies).
+All features opt-in: enabled=False by default.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class SafeModeConfig:
+    """Emergency global safe mode (F5). Blocks all tool dispatch when enabled."""
+
+    enabled: bool = False
+
+
+@dataclass
+class BudgetConfig:
+    """Time-window budget controller (F1). Limits tokens/calls/cost per window."""
+
+    enabled: bool = False
+    max_tokens: int = 100_000
+    max_calls: int = 1_000
+    max_cost_usd: float = 10.0
+    window_seconds: int = 3600
+
+
+@dataclass
+class CircuitBreakerConfig:
+    """Deterministic failure circuit breaker (F2). Trips on repeated identical errors."""
+
+    enabled: bool = False
+    failure_threshold: int = 5
+    recovery_timeout_seconds: int = 60
+
+
+@dataclass
+class EgressConfig:
+    """Egress allowlist guard (F3). Default-deny outbound HTTP."""
+
+    enabled: bool = False
+    allowed_hosts: List[str] = field(default_factory=list)
+
+
+@dataclass
+class SecretGuardConfig:
+    """Secret-aware outbound guard (F4). Scans outbound payloads for credentials."""
+
+    enabled: bool = False
+    patterns: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ShieldConfig:
+    """Top-level shield configuration.
+
+    All features disabled by default -- zero behavioral impact.
+    Wire into VeronicaIntegration via the ``shield`` parameter.
+    """
+
+    safe_mode: SafeModeConfig = field(default_factory=SafeModeConfig)
+    budget: BudgetConfig = field(default_factory=BudgetConfig)
+    circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
+    egress: EgressConfig = field(default_factory=EgressConfig)
+    secret_guard: SecretGuardConfig = field(default_factory=SecretGuardConfig)
+
+    @property
+    def is_any_enabled(self) -> bool:
+        """Return True if at least one shield feature is enabled."""
+        return any([
+            self.safe_mode.enabled,
+            self.budget.enabled,
+            self.circuit_breaker.enabled,
+            self.egress.enabled,
+            self.secret_guard.enabled,
+        ])
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dictionary (JSON-safe)."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ShieldConfig:
+        """Deserialize from a plain dictionary."""
+        return cls(
+            safe_mode=SafeModeConfig(**data.get("safe_mode", {})),
+            budget=BudgetConfig(**data.get("budget", {})),
+            circuit_breaker=CircuitBreakerConfig(**data.get("circuit_breaker", {})),
+            egress=EgressConfig(**data.get("egress", {})),
+            secret_guard=SecretGuardConfig(**data.get("secret_guard", {})),
+        )
+
+    @classmethod
+    def from_yaml(cls, path: str) -> ShieldConfig:
+        """Load configuration from a YAML or JSON file.
+
+        Accepts ``.json`` files natively.  For ``.yaml`` / ``.yml`` files,
+        PyYAML must be installed (optional dependency).
+        """
+        file_path = Path(path)
+
+        if file_path.suffix == ".json":
+            with open(file_path) as fh:
+                data = json.load(fh)
+            return cls.from_dict(data)
+
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError:
+            raise RuntimeError(
+                f"PyYAML is required to load '{file_path.name}'. "
+                "Install with: pip install pyyaml"
+            ) from None
+
+        with open(file_path) as fh:
+            data = yaml.safe_load(fh) or {}
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_env(cls) -> ShieldConfig:
+        """Build a ShieldConfig from environment variables.
+
+        Recognised variables:
+            VERONICA_SAFE_MODE=1  ->  safe_mode.enabled = True
+        """
+        config = cls()
+        if os.environ.get("VERONICA_SAFE_MODE") == "1":
+            config.safe_mode.enabled = True
+        return config

--- a/tests/test_shield_config.py
+++ b/tests/test_shield_config.py
@@ -1,0 +1,90 @@
+"""Tests for ShieldConfig (PR-1A)."""
+
+import json
+import sys
+
+import pytest
+
+from veronica_core.shield import ShieldConfig
+from veronica_core import VeronicaIntegration
+from veronica_core.backends import MemoryBackend
+
+
+class TestShieldConfig:
+    """Shield configuration unit tests."""
+
+    def test_shield_config_defaults_noop(self):
+        """Default ShieldConfig has all features disabled -- zero impact."""
+        config = ShieldConfig()
+
+        assert not config.safe_mode.enabled
+        assert not config.budget.enabled
+        assert not config.circuit_breaker.enabled
+        assert not config.egress.enabled
+        assert not config.secret_guard.enabled
+        assert not config.is_any_enabled
+
+    def test_shield_config_from_env_safe_mode(self, monkeypatch):
+        """VERONICA_SAFE_MODE=1 activates safe_mode.enabled."""
+        monkeypatch.setenv("VERONICA_SAFE_MODE", "1")
+
+        config = ShieldConfig.from_env()
+
+        assert config.safe_mode.enabled
+        assert config.is_any_enabled
+        # Other features remain disabled
+        assert not config.budget.enabled
+        assert not config.circuit_breaker.enabled
+
+    def test_shield_config_from_yaml_roundtrip(self, tmp_path):
+        """Config survives JSON roundtrip via from_yaml (no PyYAML needed)."""
+        original = ShieldConfig()
+        original.safe_mode.enabled = True
+        original.budget.enabled = True
+        original.budget.max_tokens = 50_000
+
+        # Write as JSON
+        path = tmp_path / "shield.json"
+        with open(path, "w") as fh:
+            json.dump(original.to_dict(), fh)
+
+        # Load back
+        loaded = ShieldConfig.from_yaml(str(path))
+
+        assert loaded.safe_mode.enabled
+        assert loaded.budget.enabled
+        assert loaded.budget.max_tokens == 50_000
+        assert not loaded.circuit_breaker.enabled
+        assert loaded.to_dict() == original.to_dict()
+
+    def test_from_yaml_raises_without_pyyaml(self, tmp_path, monkeypatch):
+        """from_yaml raises RuntimeError for .yaml when PyYAML is unavailable."""
+        path = tmp_path / "shield.yaml"
+        path.write_text("safe_mode:\n  enabled: true\n")
+
+        # Hide PyYAML from import machinery
+        monkeypatch.setitem(sys.modules, "yaml", None)
+
+        with pytest.raises(RuntimeError, match="PyYAML is required"):
+            ShieldConfig.from_yaml(str(path))
+
+    def test_integration_accepts_shield(self):
+        """VeronicaIntegration stores shield config without behavior change."""
+        backend = MemoryBackend()
+        shield = ShieldConfig()
+        shield.safe_mode.enabled = True
+
+        veronica = VeronicaIntegration(backend=backend, shield=shield)
+
+        assert veronica.shield is shield
+        assert veronica.shield.safe_mode.enabled
+
+    def test_integration_without_shield_unchanged(self):
+        """VeronicaIntegration works identically without shield (backward compat)."""
+        backend = MemoryBackend()
+        veronica = VeronicaIntegration(backend=backend)
+
+        assert veronica.shield is None
+        # Existing behavior unaffected
+        veronica.record_fail("test_entity")
+        assert veronica.get_fail_count("test_entity") == 1


### PR DESCRIPTION
## Summary
- Add `veronica_core.shield` package with `ShieldConfig` dataclass and 5 nested feature configs (SafeMode, Budget, CircuitBreaker, Egress, SecretGuard)
- Wire `shield: Optional[ShieldConfig] = None` into `VeronicaIntegration` (stored only, zero behavioral change)
- Support `ShieldConfig.from_env()` (VERONICA_SAFE_MODE=1) and `ShieldConfig.from_yaml()` (JSON native, PyYAML optional)
- `from_yaml()` reads JSON by default; YAML requires PyYAML and raises a clear RuntimeError if missing.

## What this does NOT do
- No pipeline, hooks, or state machine
- No behavioral impact -- shield config is stored but not acted upon
- No new external dependencies (stdlib dataclasses only)

## Test plan
- [x] test_shield_config_defaults_noop -- all features disabled by default
- [x] test_shield_config_from_env_safe_mode -- VERONICA_SAFE_MODE=1 activates
- [x] test_shield_config_from_yaml_roundtrip -- JSON serialization survives roundtrip
- [x] test_from_yaml_raises_without_pyyaml -- RuntimeError with clear message when PyYAML missing
- [x] test_integration_accepts_shield -- VeronicaIntegration stores shield param
- [x] test_integration_without_shield_unchanged -- backward compatibility preserved
- [x] Full suite: 130 passed, 4 xfailed (unchanged)