### PR TITLE
feat: add Execution Shield core types (Decision + ToolCallContext)

### DIFF
--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,3 +1,4 @@
 """VERONICA Execution Shield."""
 from veronica_core.shield.config import ShieldConfig
-__all__ = ["ShieldConfig"]
+from veronica_core.shield.types import Decision, ToolCallContext
+__all__ = ["ShieldConfig", "Decision", "ToolCallContext"]

--- a/src/veronica_core/shield/types.py
+++ b/src/veronica_core/shield/types.py
@@ -1,0 +1,42 @@
+"""Core shield types for VERONICA Execution Shield.
+
+Decision enum: possible outcomes of a shield policy check.
+ToolCallContext: immutable snapshot of a single tool invocation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Decision(str, Enum):
+    """Outcome of a shield policy evaluation."""
+
+    ALLOW = "ALLOW"
+    RETRY = "RETRY"
+    HALT = "HALT"
+    DEGRADE = "DEGRADE"
+    QUARANTINE = "QUARANTINE"
+    QUEUE = "QUEUE"
+
+
+@dataclass(frozen=True)
+class ToolCallContext:
+    """Immutable snapshot describing a single tool invocation.
+
+    All fields except ``request_id`` are optional so callers can
+    populate only what they have available.
+    """
+
+    request_id: str
+    user_id: str | None = None
+    session_id: str | None = None
+    tool_name: str | None = None
+    model: str | None = None
+    endpoint: str | None = None
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    cost_usd: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_shield_types.py
+++ b/tests/test_shield_types.py
@@ -1,0 +1,70 @@
+"""Tests for shield core types (PR-1B)."""
+
+import dataclasses
+
+import pytest
+
+from veronica_core.shield import Decision, ToolCallContext
+
+
+class TestDecision:
+    """Decision enum tests."""
+
+    def test_values_are_strings(self):
+        """Decision members are str-valued for serialization."""
+        for member in Decision:
+            assert isinstance(member.value, str)
+            assert member.value == member.name
+
+    def test_stable_members(self):
+        """All six expected members exist."""
+        expected = {"ALLOW", "RETRY", "HALT", "DEGRADE", "QUARANTINE", "QUEUE"}
+        assert {m.name for m in Decision} == expected
+
+    def test_string_comparison(self):
+        """Decision members compare equal to their string value."""
+        assert Decision.ALLOW == "ALLOW"
+        assert Decision.HALT == "HALT"
+
+
+class TestToolCallContext:
+    """ToolCallContext dataclass tests."""
+
+    def test_frozen(self):
+        """ToolCallContext rejects attribute assignment."""
+        ctx = ToolCallContext(request_id="r1")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.request_id = "r2"
+
+    def test_metadata_default_distinct(self):
+        """Each instance gets its own metadata dict."""
+        a = ToolCallContext(request_id="a")
+        b = ToolCallContext(request_id="b")
+        assert a.metadata is not b.metadata
+        assert a.metadata == {}
+
+    def test_optional_fields_default_none(self):
+        """All optional fields default to None."""
+        ctx = ToolCallContext(request_id="r1")
+        assert ctx.user_id is None
+        assert ctx.tool_name is None
+        assert ctx.tokens_in is None
+        assert ctx.cost_usd is None
+
+    def test_full_construction(self):
+        """All fields can be populated."""
+        ctx = ToolCallContext(
+            request_id="r1",
+            user_id="u1",
+            session_id="s1",
+            tool_name="bash",
+            model="gpt-5.2-codex",
+            endpoint="https://api.example.com",
+            tokens_in=100,
+            tokens_out=200,
+            cost_usd=0.005,
+            metadata={"key": "value"},
+        )
+        assert ctx.request_id == "r1"
+        assert ctx.model == "gpt-5.2-codex"
+        assert ctx.metadata == {"key": "value"}


### PR DESCRIPTION
## Summary
- Add `Decision` str enum with 6 members: ALLOW, RETRY, HALT, DEGRADE, QUARANTINE, QUEUE
- Add `ToolCallContext` frozen dataclass (immutable tool invocation snapshot, 10 fields)
- Export both from `veronica_core.shield`
- stdlib-only, zero external dependencies, zero behavioral change

Depends on #3 (PR-1A: ShieldConfig).

## Test plan
- [x] Decision values are strings and match member names
- [x] All 6 expected Decision members exist
- [x] Decision members compare equal to their string value
- [x] ToolCallContext is frozen (assignment raises FrozenInstanceError)
- [x] metadata default is distinct per instance
- [x] Optional fields default to None
- [x] Full construction with all fields
- [x] Full suite: 137 passed, 4 xfailed
- [x] ruff: 0 errors