### PR TITLE
feat: add Execution Shield hook protocols and noop implementations

### DIFF
--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,4 +1,21 @@
 """VERONICA Execution Shield."""
 from veronica_core.shield.config import ShieldConfig
+from veronica_core.shield.hooks import (
+    BudgetBoundaryHook,
+    EgressBoundaryHook,
+    PreDispatchHook,
+    RetryBoundaryHook,
+)
+from veronica_core.shield.noop import (
+    NoopBudgetBoundaryHook,
+    NoopEgressBoundaryHook,
+    NoopPreDispatchHook,
+    NoopRetryBoundaryHook,
+)
 from veronica_core.shield.types import Decision, ToolCallContext
-__all__ = ["ShieldConfig", "Decision", "ToolCallContext"]
+
+__all__ = [
+    "ShieldConfig", "Decision", "ToolCallContext",
+    "PreDispatchHook", "EgressBoundaryHook", "RetryBoundaryHook", "BudgetBoundaryHook",
+    "NoopPreDispatchHook", "NoopEgressBoundaryHook", "NoopRetryBoundaryHook", "NoopBudgetBoundaryHook",
+]

--- a/src/veronica_core/shield/hooks.py
+++ b/src/veronica_core/shield/hooks.py
@@ -1,0 +1,46 @@
+"""Hook protocols for VERONICA Execution Shield.
+
+Each protocol represents a boundary where the shield can intercept
+and make a Decision.  Returning ``None`` means "no opinion" --
+the pipeline (when wired) will treat it as ALLOW.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+@runtime_checkable
+class PreDispatchHook(Protocol):
+    """Evaluated before every LLM / tool call."""
+
+    def before_llm_call(self, ctx: ToolCallContext) -> Decision | None: ...
+
+
+@runtime_checkable
+class EgressBoundaryHook(Protocol):
+    """Evaluated before an outbound HTTP request."""
+
+    def before_egress(
+        self, ctx: ToolCallContext, url: str, method: str
+    ) -> Decision | None: ...
+
+
+@runtime_checkable
+class RetryBoundaryHook(Protocol):
+    """Evaluated when a tool call raises an exception."""
+
+    def on_error(
+        self, ctx: ToolCallContext, err: BaseException
+    ) -> Decision | None: ...
+
+
+@runtime_checkable
+class BudgetBoundaryHook(Protocol):
+    """Evaluated before recording a cost charge."""
+
+    def before_charge(
+        self, ctx: ToolCallContext, cost_usd: float
+    ) -> Decision | None: ...

--- a/src/veronica_core/shield/noop.py
+++ b/src/veronica_core/shield/noop.py
@@ -1,0 +1,43 @@
+"""No-op hook implementations for VERONICA Execution Shield.
+
+Each class satisfies the corresponding Protocol and always returns
+``None`` (no opinion), making them safe defaults.
+"""
+
+from __future__ import annotations
+
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+class NoopPreDispatchHook:
+    """Pre-dispatch hook that always defers."""
+
+    def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
+        return None
+
+
+class NoopEgressBoundaryHook:
+    """Egress boundary hook that always defers."""
+
+    def before_egress(
+        self, ctx: ToolCallContext, url: str, method: str
+    ) -> Decision | None:
+        return None
+
+
+class NoopRetryBoundaryHook:
+    """Retry boundary hook that always defers."""
+
+    def on_error(
+        self, ctx: ToolCallContext, err: BaseException
+    ) -> Decision | None:
+        return None
+
+
+class NoopBudgetBoundaryHook:
+    """Budget boundary hook that always defers."""
+
+    def before_charge(
+        self, ctx: ToolCallContext, cost_usd: float
+    ) -> Decision | None:
+        return None

--- a/tests/test_shield_hooks_noop.py
+++ b/tests/test_shield_hooks_noop.py
@@ -1,0 +1,49 @@
+"""Tests for shield hook protocols and noop implementations (PR-1C)."""
+
+from veronica_core.shield import ToolCallContext
+from veronica_core.shield.hooks import (
+    BudgetBoundaryHook,
+    EgressBoundaryHook,
+    PreDispatchHook,
+    RetryBoundaryHook,
+)
+from veronica_core.shield.noop import (
+    NoopBudgetBoundaryHook,
+    NoopEgressBoundaryHook,
+    NoopPreDispatchHook,
+    NoopRetryBoundaryHook,
+)
+
+CTX = ToolCallContext(request_id="test")
+
+
+class TestNoopHooksReturnNone:
+    """Every noop hook method returns None."""
+
+    def test_pre_dispatch(self):
+        assert NoopPreDispatchHook().before_llm_call(CTX) is None
+
+    def test_egress(self):
+        assert NoopEgressBoundaryHook().before_egress(CTX, "https://x", "GET") is None
+
+    def test_retry(self):
+        assert NoopRetryBoundaryHook().on_error(CTX, RuntimeError("boom")) is None
+
+    def test_budget(self):
+        assert NoopBudgetBoundaryHook().before_charge(CTX, 0.01) is None
+
+
+class TestProtocolConformance:
+    """Noop classes satisfy their respective Protocols."""
+
+    def test_pre_dispatch(self):
+        assert isinstance(NoopPreDispatchHook(), PreDispatchHook)
+
+    def test_egress(self):
+        assert isinstance(NoopEgressBoundaryHook(), EgressBoundaryHook)
+
+    def test_retry(self):
+        assert isinstance(NoopRetryBoundaryHook(), RetryBoundaryHook)
+
+    def test_budget(self):
+        assert isinstance(NoopBudgetBoundaryHook(), BudgetBoundaryHook)


### PR DESCRIPTION
## Summary
- Add 4 hook `Protocol` definitions in `shield/hooks.py`: PreDispatchHook, EgressBoundaryHook, RetryBoundaryHook, BudgetBoundaryHook
- Add matching noop implementations in `shield/noop.py` (all methods return `None`)
- Export all 8 symbols from `veronica_core.shield`
- stdlib-only (`typing.Protocol`), zero behavioral change, no pipeline wiring

Depends on #4 (PR-1B: Decision + ToolCallContext).

## Test plan
- [x] Each noop hook returns None
- [x] Each noop class satisfies its Protocol (`isinstance` check via `runtime_checkable`)
- [x] Full suite: 145 passed, 4 xfailed
- [x] ruff: 0 errors (PR-1C files)