### PR TITLE
feat(shield): add optional SafeModeHook (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ pytest
 Design and diagrams:
 [docs/v0.4.0-technical-artifacts.md](docs/v0.4.0-technical-artifacts.md)
 
+SafeModeHook is optional and disabled by default.
+
 ---
 
 ## License

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -14,6 +14,7 @@ from veronica_core.shield.noop import (
     NoopRetryBoundaryHook,
 )
 from veronica_core.shield.pipeline import ShieldPipeline
+from veronica_core.shield.safe_mode import SafeModeHook
 from veronica_core.shield.types import Decision, ToolCallContext
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "Decision", "ToolCallContext",
     "PreDispatchHook", "EgressBoundaryHook", "RetryBoundaryHook", "BudgetBoundaryHook",
     "NoopPreDispatchHook", "NoopEgressBoundaryHook", "NoopRetryBoundaryHook", "NoopBudgetBoundaryHook",
+    "SafeModeHook",
 ]

--- a/src/veronica_core/shield/safe_mode.py
+++ b/src/veronica_core/shield/safe_mode.py
@@ -1,0 +1,39 @@
+"""SafeMode hook for VERONICA Execution Shield.
+
+When enabled, acts as an emergency kill-switch: blocks all tool
+dispatch (pre-dispatch) and suppresses retries.  When disabled,
+returns ``None`` on every check (no opinion -- defers to pipeline).
+
+Note: SafeMode does NOT block HTTP egress or budget charges.
+Those boundaries require separate hooks (EgressBoundaryHook,
+BudgetBoundaryHook).
+"""
+
+from __future__ import annotations
+
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+class SafeModeHook:
+    """Emergency kill-switch that halts tool calls and retries."""
+
+    def __init__(self, enabled: bool = True) -> None:
+        self._enabled = enabled
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
+        """Block tool dispatch when enabled and a tool_name is present."""
+        if self._enabled and ctx.tool_name is not None:
+            return Decision.HALT
+        return None
+
+    def on_error(
+        self, ctx: ToolCallContext, err: BaseException
+    ) -> Decision | None:
+        """Suppress retries when enabled."""
+        if self._enabled:
+            return Decision.HALT
+        return None

--- a/tests/test_shield_safe_mode.py
+++ b/tests/test_shield_safe_mode.py
@@ -1,0 +1,96 @@
+"""Tests for SafeModeHook."""
+
+from veronica_core.shield import Decision, SafeModeHook, ShieldPipeline, ToolCallContext
+from veronica_core.shield.config import SafeModeConfig, ShieldConfig
+from veronica_core.shield.hooks import PreDispatchHook, RetryBoundaryHook
+
+CTX = ToolCallContext(request_id="test", tool_name="bash")
+CTX_NO_TOOL = ToolCallContext(request_id="test")
+
+
+class TestSafeModeEnabled:
+    """Enabled SafeModeHook blocks tool calls and retries."""
+
+    def test_blocks_tool_call(self):
+        hook = SafeModeHook(enabled=True)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_allows_non_tool_call(self):
+        hook = SafeModeHook(enabled=True)
+        assert hook.before_llm_call(CTX_NO_TOOL) is None
+
+    def test_blocks_empty_tool_name(self):
+        ctx = ToolCallContext(request_id="test", tool_name="")
+        hook = SafeModeHook(enabled=True)
+        assert hook.before_llm_call(ctx) is Decision.HALT
+
+    def test_blocks_retry(self):
+        hook = SafeModeHook(enabled=True)
+        assert hook.on_error(CTX, RuntimeError("boom")) is Decision.HALT
+
+
+class TestSafeModeDisabled:
+    """Disabled SafeModeHook returns None (no opinion)."""
+
+    def test_tool_call_defers(self):
+        hook = SafeModeHook(enabled=False)
+        assert hook.before_llm_call(CTX) is None
+
+    def test_retry_defers(self):
+        hook = SafeModeHook(enabled=False)
+        assert hook.on_error(CTX, RuntimeError("boom")) is None
+
+
+class TestSafeModeProtocol:
+    """SafeModeHook satisfies PreDispatchHook and RetryBoundaryHook."""
+
+    def test_is_pre_dispatch(self):
+        assert isinstance(SafeModeHook(), PreDispatchHook)
+
+    def test_is_retry_boundary(self):
+        assert isinstance(SafeModeHook(), RetryBoundaryHook)
+
+
+class TestSafeModePipelineIntegration:
+    """Pipeline wired with SafeModeHook behaves correctly."""
+
+    def test_pipeline_with_safe_mode_blocks(self):
+        hook = SafeModeHook(enabled=True)
+        pipe = ShieldPipeline(pre_dispatch=hook, retry=hook)
+        assert pipe.before_llm_call(CTX) is Decision.HALT
+        assert pipe.on_error(CTX, ValueError("v")) is Decision.HALT
+
+    def test_pipeline_without_safe_mode_allows(self):
+        pipe = ShieldPipeline()
+        assert pipe.before_llm_call(CTX) is Decision.ALLOW
+        assert pipe.on_error(CTX, ValueError("v")) is Decision.ALLOW
+
+
+class TestDefaultShieldConfigUnchanged:
+    """Default ShieldConfig produces no behavioral change (non-breaking)."""
+
+    def test_default_config_safe_mode_disabled(self):
+        cfg = ShieldConfig()
+        assert cfg.safe_mode.enabled is False
+
+    def test_default_config_no_features_enabled(self):
+        cfg = ShieldConfig()
+        assert cfg.is_any_enabled is False
+
+
+class TestIntegrationWiring:
+    """VeronicaIntegration wires SafeModeHook only when enabled."""
+
+    def test_safe_mode_disabled_no_hook(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        vi = VeronicaIntegration(shield=ShieldConfig())
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.ALLOW
+
+    def test_safe_mode_enabled_blocks(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        cfg = ShieldConfig(safe_mode=SafeModeConfig(enabled=True))
+        vi = VeronicaIntegration(shield=cfg)
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.HALT
+        assert vi._shield_pipeline.on_error(CTX, RuntimeError("x")) is Decision.HALT


### PR DESCRIPTION
## Summary
- Add `SafeModeHook` -- first concrete Execution Shield hook implementation
- Wire into `VeronicaIntegration` via `ShieldConfig(safe_mode=SafeModeConfig(enabled=True))`
- Disabled by default. Zero behavioral change for existing users.

## Changes
- `src/veronica_core/shield/safe_mode.py` (new, 39 lines)
- `src/veronica_core/shield/__init__.py` (export SafeModeHook)
- `src/veronica_core/integration.py` (wire SafeModeHook into pipeline)
- `tests/test_shield_safe_mode.py` (new, 14 tests)
- `README.md` (1-line note)

## Test plan
- [x] 281 passed, 4 xfailed (same xfailed as before)
- [x] Default config unchanged (SafeMode disabled)
- [x] SafeMode ON blocks tool calls + retries
- [x] SafeMode OFF = no-op (defers to pipeline)
- [x] Protocol conformance (PreDispatchHook, RetryBoundaryHook)