### PR TITLE
feat(audit): add install CTA, top risk areas, and URL sharing

### DIFF
--- a/apps/audit/styles.css
+++ b/apps/audit/styles.css
@@ -228,6 +228,52 @@ header p {
     padding: 1rem 1.25rem;
 }
 
+/* ── Score screen extras ─────────────────────────────── */
+
+.install-cta {
+    font-size: 0.9rem;
+}
+
+.install-cta code {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.3rem 0.7rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.875rem;
+    color: var(--color-primary);
+}
+
+.risk-areas {
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.risk-areas-title {
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+.risk-areas ul {
+    padding-left: 1.25rem;
+    color: var(--color-muted);
+}
+
+.risk-areas ul li {
+    margin-bottom: 0.25rem;
+}
+
+.copy-link-btn {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+}
+
+.copy-link-btn:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
 /* ── Responsive ──────────────────────────────────────── */
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Add `pip install veronica-core` CTA as styled code block after interpretation paragraph
- Show top 3 Step 2 gap questions (isGap=true) as a plaintext list — no blur, no paywall
- Encode all 9 answers into URL query string on score screen; on page load detect params and restore answers + navigate to #score
- Add Copy Link button using `navigator.clipboard.writeText`
- Add minimal CSS for `.install-cta`, `.risk-areas`, `.copy-link-btn`

## Test plan
- [ ] `node apps/audit/scoring.js` — 6/6 PASS
- [ ] Score screen shows `pip install veronica-core` code block
- [ ] Score screen shows top gap questions when gaps > 0
- [ ] Score screen shows no risk areas section when gaps = 0
- [ ] URL updates to `?q1=val...q9=val#score` on score render
- [ ] Copy Link button copies current href to clipboard
- [ ] Opening shared URL restores answers and lands on score screen
- [ ] Retake Audit clears query string and returns to step1

🤖 Generated with [Claude Code](https://claude.com/claude-code)