### PR TITLE
feat(shield): add optional BudgetWindowHook (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Design and diagrams:
 [docs/v0.4.0-technical-artifacts.md](docs/v0.4.0-technical-artifacts.md)
 
 SafeModeHook is optional and disabled by default.
+BudgetWindowHook is optional and disabled by default.
 [Execution Boundary concept](docs/execution-boundary.md)
 
 ---

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,4 +1,5 @@
 """VERONICA Execution Shield."""
+from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
 from veronica_core.shield.errors import ShieldBlockedError
 from veronica_core.shield.hooks import (
@@ -23,4 +24,5 @@ __all__ = [
     "PreDispatchHook", "EgressBoundaryHook", "RetryBoundaryHook", "BudgetBoundaryHook",
     "NoopPreDispatchHook", "NoopEgressBoundaryHook", "NoopRetryBoundaryHook", "NoopBudgetBoundaryHook",
     "SafeModeHook",
+    "BudgetWindowHook",
 ]

--- a/src/veronica_core/shield/budget_window.py
+++ b/src/veronica_core/shield/budget_window.py
@@ -1,0 +1,47 @@
+"""BudgetWindowHook for VERONICA Execution Shield.
+
+Enforces a rolling time-window call-count ceiling.  When the number of
+``before_llm_call`` invocations within the last ``window_seconds`` reaches
+``max_calls`` the hook returns ``Decision.HALT``.
+
+MVP scope: call-count based only.  USD-based budgets require provider price
+tables and are intentionally out of scope (scope creep risk).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+class BudgetWindowHook:
+    """Rolling time-window call-count limiter.
+
+    Thread-safe.  Internally tracks invocation timestamps in a deque;
+    entries older than ``window_seconds`` are pruned on every call.
+    """
+
+    def __init__(self, max_calls: int, window_seconds: float = 60.0) -> None:
+        self._max_calls = max_calls
+        self._window_seconds = window_seconds
+        self._timestamps: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
+        """Halt when the rolling call count meets or exceeds max_calls."""
+        now = time.time()
+        cutoff = now - self._window_seconds
+
+        with self._lock:
+            # Prune expired timestamps
+            while self._timestamps and self._timestamps[0] <= cutoff:
+                self._timestamps.popleft()
+
+            if len(self._timestamps) >= self._max_calls:
+                return Decision.HALT
+
+            self._timestamps.append(now)
+            return None

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -57,6 +57,18 @@ class SecretGuardConfig:
 
 
 @dataclass
+class BudgetWindowConfig:
+    """Rolling time-window call-count limiter (opt-in).
+
+    Disabled by default -- zero behavioral impact until explicitly enabled.
+    """
+
+    enabled: bool = False
+    max_calls: int = 100
+    window_seconds: float = 60.0
+
+
+@dataclass
 class ShieldConfig:
     """Top-level shield configuration.
 
@@ -69,6 +81,7 @@ class ShieldConfig:
     circuit_breaker: CircuitBreakerConfig = field(default_factory=CircuitBreakerConfig)
     egress: EgressConfig = field(default_factory=EgressConfig)
     secret_guard: SecretGuardConfig = field(default_factory=SecretGuardConfig)
+    budget_window: BudgetWindowConfig = field(default_factory=BudgetWindowConfig)
 
     @property
     def is_any_enabled(self) -> bool:
@@ -79,6 +92,7 @@ class ShieldConfig:
             self.circuit_breaker.enabled,
             self.egress.enabled,
             self.secret_guard.enabled,
+            self.budget_window.enabled,
         ])
 
     def to_dict(self) -> dict:
@@ -94,6 +108,7 @@ class ShieldConfig:
             circuit_breaker=CircuitBreakerConfig(**data.get("circuit_breaker", {})),
             egress=EgressConfig(**data.get("egress", {})),
             secret_guard=SecretGuardConfig(**data.get("secret_guard", {})),
+            budget_window=BudgetWindowConfig(**data.get("budget_window", {})),
         )
 
     @classmethod

--- a/tests/test_shield_budget_window.py
+++ b/tests/test_shield_budget_window.py
@@ -1,0 +1,163 @@
+"""Tests for BudgetWindowHook."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from veronica_core.shield import (
+    BudgetWindowHook,
+    Decision,
+    ShieldPipeline,
+    ToolCallContext,
+)
+from veronica_core.shield.config import BudgetWindowConfig, ShieldConfig
+from veronica_core.shield.hooks import PreDispatchHook
+
+CTX = ToolCallContext(request_id="test", tool_name="bash")
+
+
+class TestBudgetWindowOff:
+    """When max_calls is very large, hook never HALTs (effectively off)."""
+
+    def test_returns_none_well_below_limit(self):
+        hook = BudgetWindowHook(max_calls=1_000_000)
+        for _ in range(10):
+            assert hook.before_llm_call(CTX) is None
+
+
+class TestBudgetWindowOn:
+    """First max_calls calls return None; (max_calls+1)th call returns HALT."""
+
+    def test_first_calls_allowed(self):
+        hook = BudgetWindowHook(max_calls=3, window_seconds=60.0)
+        assert hook.before_llm_call(CTX) is None
+        assert hook.before_llm_call(CTX) is None
+        assert hook.before_llm_call(CTX) is None
+
+    def test_call_after_limit_halts(self):
+        hook = BudgetWindowHook(max_calls=3, window_seconds=60.0)
+        hook.before_llm_call(CTX)
+        hook.before_llm_call(CTX)
+        hook.before_llm_call(CTX)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_subsequent_calls_also_halt(self):
+        hook = BudgetWindowHook(max_calls=2, window_seconds=60.0)
+        hook.before_llm_call(CTX)
+        hook.before_llm_call(CTX)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+
+class TestBudgetWindowExpiry:
+    """After window_seconds, old timestamps are pruned and counter resets."""
+
+    def test_window_expiry_allows_new_calls(self, monkeypatch):
+        times = iter([0.0, 0.5, 1.0, 61.5, 62.0])
+        monkeypatch.setattr(time, "time", lambda: next(times))
+
+        hook = BudgetWindowHook(max_calls=2, window_seconds=60.0)
+        assert hook.before_llm_call(CTX) is None   # t=0.0, count=1
+        assert hook.before_llm_call(CTX) is None   # t=0.5, count=2  (already at limit)
+        assert hook.before_llm_call(CTX) is Decision.HALT  # t=1.0, HALT
+
+        # After window expires, timestamps at 0.0 and 0.5 are pruned (cutoff = 61.5-60 = 1.5)
+        assert hook.before_llm_call(CTX) is None   # t=61.5, count=1
+        assert hook.before_llm_call(CTX) is None   # t=62.0, count=2
+
+
+class TestBudgetWindowBoundary:
+    """Boundary: max_calls=1 allows first call, halts second."""
+
+    def test_max_calls_one_allows_first(self):
+        hook = BudgetWindowHook(max_calls=1, window_seconds=60.0)
+        assert hook.before_llm_call(CTX) is None
+
+    def test_max_calls_one_halts_second(self):
+        hook = BudgetWindowHook(max_calls=1, window_seconds=60.0)
+        hook.before_llm_call(CTX)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_max_calls_zero_always_halts(self):
+        hook = BudgetWindowHook(max_calls=0, window_seconds=60.0)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+
+class TestBudgetWindowProtocol:
+    """BudgetWindowHook satisfies PreDispatchHook protocol."""
+
+    def test_is_pre_dispatch(self):
+        assert isinstance(BudgetWindowHook(max_calls=10), PreDispatchHook)
+
+
+class TestBudgetWindowPipelineIntegration:
+    """Pipeline wired with BudgetWindowHook behaves correctly."""
+
+    def test_pipeline_halts_after_limit(self):
+        hook = BudgetWindowHook(max_calls=2, window_seconds=60.0)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        assert pipe.before_llm_call(CTX) is Decision.ALLOW  # call 1
+        assert pipe.before_llm_call(CTX) is Decision.ALLOW  # call 2
+        assert pipe.before_llm_call(CTX) is Decision.HALT   # call 3 (over limit)
+
+    def test_pipeline_without_hook_always_allows(self):
+        pipe = ShieldPipeline()
+        for _ in range(5):
+            assert pipe.before_llm_call(CTX) is Decision.ALLOW
+
+
+class TestDefaultBudgetWindowConfig:
+    """Default BudgetWindowConfig is disabled (non-breaking)."""
+
+    def test_default_disabled(self):
+        cfg = BudgetWindowConfig()
+        assert cfg.enabled is False
+
+    def test_shield_config_default_budget_window_disabled(self):
+        cfg = ShieldConfig()
+        assert cfg.budget_window.enabled is False
+
+    def test_shield_config_is_any_enabled_false_by_default(self):
+        cfg = ShieldConfig()
+        assert cfg.is_any_enabled is False
+
+    def test_shield_config_is_any_enabled_true_when_budget_window_on(self):
+        cfg = ShieldConfig(budget_window=BudgetWindowConfig(enabled=True, max_calls=10))
+        assert cfg.is_any_enabled is True
+
+
+class TestBudgetWindowIntegrationWiring:
+    """VeronicaIntegration wires BudgetWindowHook only when enabled."""
+
+    def test_disabled_allows_all(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        vi = VeronicaIntegration(shield=ShieldConfig())
+        for _ in range(5):
+            assert vi._shield_pipeline.before_llm_call(CTX) is Decision.ALLOW
+
+    def test_enabled_halts_after_max_calls(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        cfg = ShieldConfig(
+            budget_window=BudgetWindowConfig(enabled=True, max_calls=3, window_seconds=60.0)
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.ALLOW  # call 1
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.ALLOW  # call 2
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.ALLOW  # call 3
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.HALT   # call 4
+
+    def test_safe_mode_takes_priority_over_budget_window(self):
+        from veronica_core.integration import VeronicaIntegration
+        from veronica_core.shield.config import SafeModeConfig
+
+        cfg = ShieldConfig(
+            safe_mode=SafeModeConfig(enabled=True),
+            budget_window=BudgetWindowConfig(enabled=True, max_calls=1000),
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        # safe_mode blocks all tool calls immediately
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.HALT


### PR DESCRIPTION
## Summary

- Add `BudgetWindowHook`: rolling time-window call-count ceiling (`max_calls` per `window_seconds`)
- Add `BudgetWindowConfig` dataclass in `ShieldConfig` (disabled by default, zero behavioral impact)
- Wire into `VeronicaIntegration` — `safe_mode` takes priority when both enabled
- 18 new tests in `tests/test_shield_budget_window.py`; all 299 existing tests still pass

## Implementation notes

- MVP: call-count based only (USD requires price tables = out of scope)
- Thread-safe via `threading.Lock` + `collections.deque`
- Timestamps pruned on every `before_llm_call` invocation (O(prune) amortized)
- `max_calls=0` always HALTs; `max_calls=N` allows N calls then HALTs on N+1

## Test plan

- [x] `python -m pytest tests/ -x -q` — 299 passed, 4 xfailed
- [x] Disabled by default: `ShieldConfig().is_any_enabled is False`
- [x] Window expiry resets counter (monkeypatched `time.time`)
- [x] Thread safety: `threading.Lock` guards deque mutations
- [x] Protocol conformance: `isinstance(BudgetWindowHook(...), PreDispatchHook)`
- [x] Integration wiring: `safe_mode` overrides `budget_window`