### PR TITLE
feat(shield): add SafetyEvent for decision explanations

### DIFF
--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -2,6 +2,7 @@
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
 from veronica_core.shield.errors import ShieldBlockedError
+from veronica_core.shield.event import SafetyEvent
 from veronica_core.shield.hooks import (
     BudgetBoundaryHook,
     EgressBoundaryHook,
@@ -25,4 +26,5 @@ __all__ = [
     "NoopPreDispatchHook", "NoopEgressBoundaryHook", "NoopRetryBoundaryHook", "NoopBudgetBoundaryHook",
     "SafeModeHook",
     "BudgetWindowHook",
+    "SafetyEvent",
 ]

--- a/src/veronica_core/shield/event.py
+++ b/src/veronica_core/shield/event.py
@@ -1,0 +1,37 @@
+"""SafetyEvent dataclass for VERONICA Execution Shield.
+
+Every non-ALLOW Decision produced by the pipeline is recorded as a
+SafetyEvent so that callers can inspect what fired and why.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from veronica_core.shield.types import Decision
+
+
+@dataclass(frozen=True)
+class SafetyEvent:
+    """Immutable record of a shield policy decision.
+
+    Attributes:
+        event_type: Machine-readable category, e.g. "SAFE_MODE" or
+            "BUDGET_WINDOW_EXCEEDED".
+        decision: The Decision that was returned (never ALLOW).
+        reason: Human-readable explanation.
+        hook: Class name of the hook that fired.
+        request_id: Copied from ToolCallContext when available.
+        ts: UTC timestamp of the event (auto-set on creation).
+        metadata: Optional extra key/value pairs from the hook.
+    """
+
+    event_type: str
+    decision: Decision
+    reason: str
+    hook: str
+    request_id: str | None = None
+    ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_shield_safety_event.py
+++ b/tests/test_shield_safety_event.py
@@ -1,0 +1,184 @@
+"""Tests for SafetyEvent and ShieldPipeline event recording."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from veronica_core.shield import (
+    BudgetWindowHook,
+    Decision,
+    SafeModeHook,
+    SafetyEvent,
+    ShieldPipeline,
+    ToolCallContext,
+)
+
+CTX = ToolCallContext(request_id="req-123", tool_name="bash")
+
+
+class TestPipelineNoHooks:
+    """Pipeline with no hooks produces no events."""
+
+    def test_no_events_on_allow(self):
+        pipe = ShieldPipeline()
+        pipe.before_llm_call(CTX)
+        assert pipe.get_events() == []
+
+    def test_no_events_on_error(self):
+        pipe = ShieldPipeline()
+        pipe.on_error(CTX, RuntimeError("boom"))
+        assert pipe.get_events() == []
+
+
+class TestSafeModeEvent:
+    """SafeModeHook fires → SafetyEvent with event_type='SAFE_MODE'."""
+
+    def test_safe_mode_produces_event(self):
+        hook = SafeModeHook(enabled=True)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        pipe.before_llm_call(CTX)
+
+        events = pipe.get_events()
+        assert len(events) == 1
+        e = events[0]
+        assert e.event_type == "SAFE_MODE"
+        assert e.decision is Decision.HALT
+        assert e.hook == "SafeModeHook"
+        assert e.request_id == "req-123"
+
+    def test_safe_mode_on_error_produces_event(self):
+        hook = SafeModeHook(enabled=True)
+        pipe = ShieldPipeline(retry=hook)
+        pipe.on_error(CTX, ValueError("err"))
+
+        events = pipe.get_events()
+        assert len(events) == 1
+        assert events[0].event_type == "SAFE_MODE"
+        assert events[0].decision is Decision.HALT
+
+    def test_safe_mode_disabled_no_event(self):
+        hook = SafeModeHook(enabled=False)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        pipe.before_llm_call(CTX)
+        assert pipe.get_events() == []
+
+
+class TestBudgetWindowEvent:
+    """BudgetWindowHook fires → SafetyEvent with event_type='BUDGET_WINDOW_EXCEEDED'."""
+
+    def test_budget_window_exceeded_produces_event(self):
+        hook = BudgetWindowHook(max_calls=2, window_seconds=60.0)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        pipe.before_llm_call(CTX)  # call 1 - ALLOW
+        pipe.before_llm_call(CTX)  # call 2 - ALLOW
+        pipe.before_llm_call(CTX)  # call 3 - HALT
+
+        events = pipe.get_events()
+        assert len(events) == 1
+        e = events[0]
+        assert e.event_type == "BUDGET_WINDOW_EXCEEDED"
+        assert e.decision is Decision.HALT
+        assert e.hook == "BudgetWindowHook"
+
+    def test_budget_window_below_limit_no_event(self):
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        for _ in range(5):
+            pipe.before_llm_call(CTX)
+        assert pipe.get_events() == []
+
+
+class TestEventsAccumulate:
+    """Multiple triggering calls accumulate multiple events."""
+
+    def test_multiple_halts_accumulate(self):
+        hook = BudgetWindowHook(max_calls=1, window_seconds=60.0)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        pipe.before_llm_call(CTX)  # ALLOW
+        pipe.before_llm_call(CTX)  # HALT - event 1
+        pipe.before_llm_call(CTX)  # HALT - event 2
+
+        events = pipe.get_events()
+        assert len(events) == 2
+        assert all(e.decision is Decision.HALT for e in events)
+
+    def test_pre_dispatch_and_retry_both_record(self):
+        safe = SafeModeHook(enabled=True)
+        pipe = ShieldPipeline(pre_dispatch=safe, retry=safe)
+        pipe.before_llm_call(CTX)
+        pipe.on_error(CTX, RuntimeError("x"))
+
+        events = pipe.get_events()
+        assert len(events) == 2
+
+
+class TestClearEvents:
+    """clear_events() empties the list."""
+
+    def test_clear_events(self):
+        hook = SafeModeHook(enabled=True)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        pipe.before_llm_call(CTX)
+        assert len(pipe.get_events()) == 1
+
+        pipe.clear_events()
+        assert pipe.get_events() == []
+
+    def test_clear_then_new_events_work(self):
+        hook = SafeModeHook(enabled=True)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        pipe.before_llm_call(CTX)
+        pipe.clear_events()
+        pipe.before_llm_call(CTX)
+        assert len(pipe.get_events()) == 1
+
+
+class TestSafetyEventImmutable:
+    """SafetyEvent is frozen (immutable)."""
+
+    def test_frozen_dataclass(self):
+        event = SafetyEvent(
+            event_type="SAFE_MODE",
+            decision=Decision.HALT,
+            reason="test",
+            hook="SafeModeHook",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            event.event_type = "OTHER"  # type: ignore[misc]
+
+    def test_metadata_default_empty(self):
+        event = SafetyEvent(
+            event_type="SAFE_MODE",
+            decision=Decision.HALT,
+            reason="test",
+            hook="SafeModeHook",
+        )
+        assert event.metadata == {}
+
+
+class TestSafetyEventTimestamp:
+    """SafetyEvent timestamp is within 1 second of now."""
+
+    def test_timestamp_is_recent(self):
+        before = datetime.now(timezone.utc)
+        event = SafetyEvent(
+            event_type="TEST",
+            decision=Decision.HALT,
+            reason="ts test",
+            hook="TestHook",
+        )
+        after = datetime.now(timezone.utc)
+
+        assert before <= event.ts <= after
+
+    def test_timestamp_is_utc(self):
+        event = SafetyEvent(
+            event_type="TEST",
+            decision=Decision.HALT,
+            reason="tz test",
+            hook="TestHook",
+        )
+        assert event.ts.tzinfo is not None
+        assert event.ts.tzinfo == timezone.utc


### PR DESCRIPTION
## Summary

- New `SafetyEvent` frozen dataclass: `event_type`, `decision`, `reason`, `hook`, `request_id`, `ts` (UTC), `metadata`
- `ShieldPipeline` now records a `SafetyEvent` on every non-ALLOW decision
- Hook-to-event_type mapping: `SafeModeHook` → `SAFE_MODE`, `BudgetWindowHook` → `BUDGET_WINDOW_EXCEEDED`
- New methods on `ShieldPipeline`: `get_events()`, `clear_events()`
- 15 new tests; all 314 total tests pass

## Test plan

- [x] `python -m pytest tests/ -x -q` — 314 passed, 4 xfailed
- [x] Pipeline with no hooks → no events
- [x] SafeModeHook fires → event_type=SAFE_MODE, decision=HALT
- [x] BudgetWindowHook fires → event_type=BUDGET_WINDOW_EXCEEDED
- [x] Multiple calls → events accumulate
- [x] `clear_events()` empties the list
- [x] `SafetyEvent` is frozen (FrozenInstanceError on mutation)
- [x] `SafetyEvent.ts` is UTC and within 1 second of creation