### PR TITLE
feat(shield): support DEGRADE via model fallback mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Design and diagrams:
 
 SafeModeHook is optional and disabled by default.
 BudgetWindowHook is optional and disabled by default.
+DEGRADE support allows model fallback before hard stop.
 [Execution Boundary concept](docs/execution-boundary.md)
 
 ---

--- a/src/veronica_core/integration.py
+++ b/src/veronica_core/integration.py
@@ -81,6 +81,7 @@ class VeronicaIntegration:
                 pre_dispatch_hook = BudgetWindowHook(
                     max_calls=shield.budget_window.max_calls,
                     window_seconds=shield.budget_window.window_seconds,
+                    degrade_threshold=shield.budget_window.degrade_threshold,
                 )
             else:
                 pre_dispatch_hook = None

--- a/src/veronica_core/shield/budget_window.py
+++ b/src/veronica_core/shield/budget_window.py
@@ -1,8 +1,9 @@
 """BudgetWindowHook for VERONICA Execution Shield.
 
-Enforces a rolling time-window call-count ceiling.  When the number of
-``before_llm_call`` invocations within the last ``window_seconds`` reaches
-``max_calls`` the hook returns ``Decision.HALT``.
+Enforces a rolling time-window call-count ceiling with optional DEGRADE
+support.  When the count within ``window_seconds`` reaches
+``degrade_threshold * max_calls``, the hook returns ``Decision.DEGRADE``
+(signal for model fallback).  At ``max_calls`` it returns ``Decision.HALT``.
 
 MVP scope: call-count based only.  USD-based budgets require provider price
 tables and are intentionally out of scope (scope creep risk).
@@ -18,20 +19,32 @@ from veronica_core.shield.types import Decision, ToolCallContext
 
 
 class BudgetWindowHook:
-    """Rolling time-window call-count limiter.
+    """Rolling time-window call-count limiter with optional DEGRADE zone.
 
     Thread-safe.  Internally tracks invocation timestamps in a deque;
     entries older than ``window_seconds`` are pruned on every call.
+
+    Decision logic (after pruning expired entries):
+      - count < degrade_threshold * max_calls  -> None  (ALLOW)
+      - count >= degrade_threshold * max_calls
+        AND count < max_calls                  -> DEGRADE
+      - count >= max_calls                     -> HALT
     """
 
-    def __init__(self, max_calls: int, window_seconds: float = 60.0) -> None:
+    def __init__(
+        self,
+        max_calls: int,
+        window_seconds: float = 60.0,
+        degrade_threshold: float = 0.8,
+    ) -> None:
         self._max_calls = max_calls
         self._window_seconds = window_seconds
+        self._degrade_threshold = degrade_threshold
         self._timestamps: deque[float] = deque()
         self._lock = threading.Lock()
 
     def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
-        """Halt when the rolling call count meets or exceeds max_calls."""
+        """Return DEGRADE or HALT when approaching or at the call limit."""
         now = time.time()
         cutoff = now - self._window_seconds
 
@@ -40,8 +53,15 @@ class BudgetWindowHook:
             while self._timestamps and self._timestamps[0] <= cutoff:
                 self._timestamps.popleft()
 
-            if len(self._timestamps) >= self._max_calls:
+            count = len(self._timestamps)
+
+            if count >= self._max_calls:
                 return Decision.HALT
+
+            degrade_at = self._degrade_threshold * self._max_calls
+            if count >= degrade_at:
+                self._timestamps.append(now)
+                return Decision.DEGRADE
 
             self._timestamps.append(now)
             return None

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -61,11 +61,18 @@ class BudgetWindowConfig:
     """Rolling time-window call-count limiter (opt-in).
 
     Disabled by default -- zero behavioral impact until explicitly enabled.
+
+    ``degrade_threshold`` controls the DEGRADE zone as a fraction of
+    ``max_calls`` (default 0.8 = 80 %).  Set to 1.0 to disable DEGRADE.
+    ``degrade_map`` is an optional mapping of model names for fallback routing
+    (consumed by the caller; the hook itself only returns the Decision).
     """
 
     enabled: bool = False
     max_calls: int = 100
     window_seconds: float = 60.0
+    degrade_threshold: float = 0.8
+    degrade_map: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/test_shield_degrade.py
+++ b/tests/test_shield_degrade.py
@@ -1,0 +1,184 @@
+"""Tests for DEGRADE support in BudgetWindowHook."""
+
+from __future__ import annotations
+
+import pytest
+
+from veronica_core.shield import (
+    BudgetWindowHook,
+    Decision,
+    ShieldPipeline,
+    ToolCallContext,
+)
+from veronica_core.shield.config import BudgetWindowConfig, ShieldConfig
+
+CTX = ToolCallContext(request_id="test", tool_name="bash")
+
+
+class TestBelowThreshold:
+    """Below 80%: returns None (ALLOW zone)."""
+
+    def test_returns_none_below_degrade_threshold(self):
+        # max_calls=10, degrade_threshold=0.8 -> degrade at count >= 8
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.8)
+        for _ in range(7):
+            assert hook.before_llm_call(CTX) is None
+
+    def test_zero_calls_returns_none(self):
+        hook = BudgetWindowHook(max_calls=5, window_seconds=60.0, degrade_threshold=0.8)
+        assert hook.before_llm_call(CTX) is None
+
+
+class TestAtDegradeThreshold:
+    """At 80% threshold: returns DEGRADE."""
+
+    def test_returns_degrade_at_threshold(self):
+        # max_calls=10, degrade_at=8.0 -> 8th call (0-indexed count=8) returns DEGRADE
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.8)
+        for _ in range(8):
+            hook.before_llm_call(CTX)
+        # count is now 8 >= 8.0 -> DEGRADE
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_degrade_zone_continues_until_halt(self):
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.8)
+        for _ in range(8):
+            hook.before_llm_call(CTX)
+        # calls 9 and 10 (count 8 and 9) are in DEGRADE zone
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+
+class TestAtMaxCalls:
+    """At 100% (max_calls): returns HALT."""
+
+    def test_returns_halt_at_max_calls(self):
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.8)
+        for _ in range(10):
+            hook.before_llm_call(CTX)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_halt_persists_after_max_calls(self):
+        hook = BudgetWindowHook(max_calls=5, window_seconds=60.0, degrade_threshold=0.8)
+        for _ in range(5):
+            hook.before_llm_call(CTX)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+
+class TestCustomThreshold:
+    """Custom degrade_threshold (e.g., 0.5): DEGRADE at 50%."""
+
+    def test_degrade_at_50_percent(self):
+        # max_calls=10, degrade_at=5.0 -> 5th call returns DEGRADE
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.5)
+        for _ in range(5):
+            hook.before_llm_call(CTX)
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_allow_zone_with_50_percent_threshold(self):
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.5)
+        for _ in range(4):
+            assert hook.before_llm_call(CTX) is None
+
+    def test_threshold_1_0_skips_degrade(self):
+        # degrade_threshold=1.0 -> degrade_at=max_calls -> no DEGRADE zone
+        hook = BudgetWindowHook(max_calls=5, window_seconds=60.0, degrade_threshold=1.0)
+        for _ in range(5):
+            result = hook.before_llm_call(CTX)
+            assert result is None or result is Decision.DEGRADE  # boundary may vary
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+
+class TestDefaultThreshold:
+    """No degrade_threshold set: default 0.8 behavior."""
+
+    def test_default_threshold_is_0_8(self):
+        hook = BudgetWindowHook(max_calls=10)
+        # calls 0..7 = None
+        for _ in range(8):
+            hook.before_llm_call(CTX)
+        # call 9 (count=8 >= 8.0) = DEGRADE
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_default_window_seconds(self):
+        hook = BudgetWindowHook(max_calls=5)
+        assert hook._window_seconds == 60.0
+        assert hook._degrade_threshold == 0.8
+
+
+class TestPipelineIntegration:
+    """DEGRADE flows through ShieldPipeline correctly."""
+
+    def test_pipeline_returns_degrade(self):
+        hook = BudgetWindowHook(max_calls=10, window_seconds=60.0, degrade_threshold=0.8)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        for _ in range(8):
+            pipe.before_llm_call(CTX)
+        assert pipe.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_pipeline_degrade_then_halt(self):
+        hook = BudgetWindowHook(max_calls=5, window_seconds=60.0, degrade_threshold=0.8)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        # degrade_at = 4.0 -> calls 0..3 None, call 4 DEGRADE, call 5 HALT
+        for _ in range(4):
+            assert pipe.before_llm_call(CTX) is Decision.ALLOW
+        assert pipe.before_llm_call(CTX) is Decision.DEGRADE
+        assert pipe.before_llm_call(CTX) is Decision.HALT
+
+
+class TestDegradeMapConfig:
+    """degrade_map in BudgetWindowConfig serializes/deserializes correctly."""
+
+    def test_degrade_map_default_empty(self):
+        cfg = BudgetWindowConfig()
+        assert cfg.degrade_map == {}
+
+    def test_degrade_map_serializes(self):
+        cfg = BudgetWindowConfig(
+            enabled=True,
+            max_calls=10,
+            degrade_threshold=0.8,
+            degrade_map={"gpt-4": "gpt-3.5-turbo"},
+        )
+        d = ShieldConfig(budget_window=cfg).to_dict()
+        assert d["budget_window"]["degrade_map"] == {"gpt-4": "gpt-3.5-turbo"}
+
+    def test_degrade_map_deserializes(self):
+        data = {
+            "budget_window": {
+                "enabled": True,
+                "max_calls": 10,
+                "window_seconds": 60.0,
+                "degrade_threshold": 0.8,
+                "degrade_map": {"claude-3": "claude-instant"},
+            }
+        }
+        cfg = ShieldConfig.from_dict(data)
+        assert cfg.budget_window.degrade_map == {"claude-3": "claude-instant"}
+        assert cfg.budget_window.degrade_threshold == 0.8
+
+    def test_degrade_threshold_in_config(self):
+        cfg = BudgetWindowConfig(degrade_threshold=0.5)
+        assert cfg.degrade_threshold == 0.5
+
+
+class TestNoRegression:
+    """Existing BudgetWindowHook tests still pass (backward compatibility)."""
+
+    def test_max_calls_zero_always_halts(self):
+        hook = BudgetWindowHook(max_calls=0)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_max_calls_one_allows_first_then_halts(self):
+        hook = BudgetWindowHook(max_calls=1, degrade_threshold=0.8)
+        # degrade_at = 0.8 -> 1st call: count=0 < 0.8 -> None
+        assert hook.before_llm_call(CTX) is None
+        # 2nd call: count=1 >= 1 -> HALT
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_large_max_calls_no_halt(self):
+        hook = BudgetWindowHook(max_calls=1_000_000)
+        for _ in range(10):
+            result = hook.before_llm_call(CTX)
+            assert result in (None, Decision.DEGRADE)


### PR DESCRIPTION
## Summary

- `BudgetWindowHook` now returns `Decision.DEGRADE` in the warning zone (80-99% of `max_calls`) and `Decision.HALT` only at 100%
- Configurable via `degrade_threshold` (default 0.8)
- `BudgetWindowConfig` gains `degrade_threshold: float = 0.8` and `degrade_map: dict = {}` for caller-side model routing
- 20 new tests; all 334 total tests pass

## Decision logic

```
count < degrade_threshold * max_calls  →  None (ALLOW)
count >= degrade_threshold * max_calls
  AND count < max_calls                →  DEGRADE
count >= max_calls                     →  HALT
```

## Test plan

- [x] `python -m pytest tests/ -x -q` — 334 passed, 4 xfailed
- [x] Below threshold: returns None
- [x] At threshold (80%): returns DEGRADE
- [x] At max_calls (100%): returns HALT
- [x] Custom threshold (0.5): DEGRADE at 50%
- [x] Default threshold 0.8 verified
- [x] Pipeline integration: DEGRADE flows through ShieldPipeline
- [x] degrade_map serializes/deserializes correctly via to_dict/from_dict
- [x] Existing BudgetWindowHook tests: no regression