### PR TITLE
feat(shield): add optional TokenBudgetHook (opt-in)

### DIFF
--- a/src/veronica_core/integration.py
+++ b/src/veronica_core/integration.py
@@ -20,6 +20,7 @@ from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
 from veronica_core.shield.pipeline import ShieldPipeline
 from veronica_core.shield.safe_mode import SafeModeHook
+from veronica_core.shield.token_budget import TokenBudgetHook
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,12 @@ class VeronicaIntegration:
             # so there is no point also running BudgetWindowHook.
             if safe_hook is not None:
                 pre_dispatch_hook = safe_hook
+            elif shield.token_budget.enabled:
+                pre_dispatch_hook = TokenBudgetHook(
+                    max_output_tokens=shield.token_budget.max_output_tokens,
+                    max_total_tokens=shield.token_budget.max_total_tokens,
+                    degrade_threshold=shield.token_budget.degrade_threshold,
+                )
             elif shield.budget_window.enabled:
                 pre_dispatch_hook = BudgetWindowHook(
                     max_calls=shield.budget_window.max_calls,

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,6 +1,7 @@
 """VERONICA Execution Shield."""
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
+from veronica_core.shield.token_budget import TokenBudgetHook
 from veronica_core.shield.errors import ShieldBlockedError
 from veronica_core.shield.event import SafetyEvent
 from veronica_core.shield.hooks import (
@@ -26,5 +27,6 @@ __all__ = [
     "NoopPreDispatchHook", "NoopEgressBoundaryHook", "NoopRetryBoundaryHook", "NoopBudgetBoundaryHook",
     "SafeModeHook",
     "BudgetWindowHook",
+    "TokenBudgetHook",
     "SafetyEvent",
 ]

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -76,6 +76,21 @@ class BudgetWindowConfig:
 
 
 @dataclass
+class TokenBudgetConfig:
+    """Token-based budget limiter (opt-in).
+
+    Disabled by default. When enabled, enforces cumulative token limits
+    with optional DEGRADE zone at degrade_threshold.
+    Set max_total_tokens=0 to track output tokens only.
+    """
+
+    enabled: bool = False
+    max_output_tokens: int = 100_000
+    max_total_tokens: int = 0  # 0 = output-only tracking
+    degrade_threshold: float = 0.8
+
+
+@dataclass
 class ShieldConfig:
     """Top-level shield configuration.
 
@@ -89,6 +104,7 @@ class ShieldConfig:
     egress: EgressConfig = field(default_factory=EgressConfig)
     secret_guard: SecretGuardConfig = field(default_factory=SecretGuardConfig)
     budget_window: BudgetWindowConfig = field(default_factory=BudgetWindowConfig)
+    token_budget: TokenBudgetConfig = field(default_factory=TokenBudgetConfig)
 
     @property
     def is_any_enabled(self) -> bool:
@@ -100,6 +116,7 @@ class ShieldConfig:
             self.egress.enabled,
             self.secret_guard.enabled,
             self.budget_window.enabled,
+            self.token_budget.enabled,
         ])
 
     def to_dict(self) -> dict:
@@ -116,6 +133,7 @@ class ShieldConfig:
             egress=EgressConfig(**data.get("egress", {})),
             secret_guard=SecretGuardConfig(**data.get("secret_guard", {})),
             budget_window=BudgetWindowConfig(**data.get("budget_window", {})),
+            token_budget=TokenBudgetConfig(**data.get("token_budget", {})),
         )
 
     @classmethod

--- a/src/veronica_core/shield/pipeline.py
+++ b/src/veronica_core/shield/pipeline.py
@@ -22,6 +22,7 @@ from veronica_core.shield.types import Decision, ToolCallContext
 _HOOK_EVENT_TYPES: dict[str, str] = {
     "SafeModeHook": "SAFE_MODE",
     "BudgetWindowHook": "BUDGET_WINDOW_EXCEEDED",
+    "TokenBudgetHook": "TOKEN_BUDGET_EXCEEDED",
     "BudgetBoundaryHook": "BUDGET_EXCEEDED",
     "EgressBoundaryHook": "EGRESS_BLOCKED",
     "RetryBoundaryHook": "RETRY_BLOCKED",

--- a/src/veronica_core/shield/token_budget.py
+++ b/src/veronica_core/shield/token_budget.py
@@ -1,0 +1,87 @@
+"""TokenBudgetHook for VERONICA Execution Shield.
+
+Enforces cumulative token budget with optional DEGRADE support.
+When output tokens reach degrade_threshold * max_output_tokens,
+returns Decision.DEGRADE. At max_output_tokens, returns Decision.HALT.
+
+MVP: caller reports usage via record_usage(). No automatic counting.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+class TokenBudgetHook:
+    """Cumulative token budget limiter with optional DEGRADE zone.
+
+    Thread-safe. Caller must report usage via record_usage() after each call.
+    The hook checks accumulated totals in before_llm_call().
+
+    Decision logic:
+      - output_total >= max_output_tokens          -> HALT
+      - output_total >= degrade_threshold * max_out -> DEGRADE
+      - total_total >= max_total_tokens (if set)    -> HALT
+      - total_total >= degrade_threshold * max_total -> DEGRADE (if set)
+      - otherwise                                   -> None (ALLOW)
+    """
+
+    def __init__(
+        self,
+        max_output_tokens: int,
+        max_total_tokens: int = 0,  # 0 = disabled
+        degrade_threshold: float = 0.8,
+    ) -> None:
+        self._max_output_tokens = max_output_tokens
+        self._max_total_tokens = max_total_tokens
+        self._degrade_threshold = degrade_threshold
+        self._output_total: int = 0
+        self._input_total: int = 0
+        self._lock = threading.Lock()
+
+    @property
+    def output_total(self) -> int:
+        with self._lock:
+            return self._output_total
+
+    @property
+    def input_total(self) -> int:
+        with self._lock:
+            return self._input_total
+
+    @property
+    def total(self) -> int:
+        with self._lock:
+            return self._output_total + self._input_total
+
+    def record_usage(self, output_tokens: int, input_tokens: int = 0) -> None:
+        """Record token usage after a call completes."""
+        with self._lock:
+            self._output_total += output_tokens
+            self._input_total += input_tokens
+
+    def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
+        """Check token budget before allowing next call."""
+        with self._lock:
+            # Check output budget
+            if self._output_total >= self._max_output_tokens:
+                return Decision.HALT
+
+            degrade_at_output = self._degrade_threshold * self._max_output_tokens
+            output_degraded = self._output_total >= degrade_at_output
+
+            # Check total budget (if enabled)
+            total_degraded = False
+            if self._max_total_tokens > 0:
+                total = self._output_total + self._input_total
+                if total >= self._max_total_tokens:
+                    return Decision.HALT
+                degrade_at_total = self._degrade_threshold * self._max_total_tokens
+                total_degraded = total >= degrade_at_total
+
+            if output_degraded or total_degraded:
+                return Decision.DEGRADE
+
+            return None

--- a/tests/test_shield_token_budget.py
+++ b/tests/test_shield_token_budget.py
@@ -1,0 +1,174 @@
+"""Tests for TokenBudgetHook."""
+
+from __future__ import annotations
+
+import pytest
+
+from veronica_core.shield import (
+    Decision,
+    ShieldPipeline,
+    TokenBudgetHook,
+    ToolCallContext,
+)
+from veronica_core.shield.config import ShieldConfig, TokenBudgetConfig
+from veronica_core.shield.hooks import PreDispatchHook
+
+CTX = ToolCallContext(request_id="test", tool_name="llm")
+
+
+class TestTokenBudgetOff:
+    """When budget is very large, hook never triggers."""
+
+    def test_returns_none_well_below_limit(self):
+        hook = TokenBudgetHook(max_output_tokens=1_000_000)
+        for _ in range(10):
+            assert hook.before_llm_call(CTX) is None
+
+
+class TestTokenBudgetOn:
+    """Basic HALT behavior."""
+
+    def test_halts_when_output_at_limit(self):
+        hook = TokenBudgetHook(max_output_tokens=100)
+        hook.record_usage(output_tokens=100)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_allows_before_limit(self):
+        hook = TokenBudgetHook(max_output_tokens=100)
+        hook.record_usage(output_tokens=50)
+        assert hook.before_llm_call(CTX) is None
+
+    def test_halts_when_over_limit(self):
+        hook = TokenBudgetHook(max_output_tokens=100)
+        hook.record_usage(output_tokens=150)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+
+class TestTokenBudgetDegrade:
+    """DEGRADE zone tests."""
+
+    def test_degrade_at_threshold(self):
+        hook = TokenBudgetHook(max_output_tokens=100, degrade_threshold=0.8)
+        hook.record_usage(output_tokens=80)
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_degrade_between_threshold_and_limit(self):
+        hook = TokenBudgetHook(max_output_tokens=100, degrade_threshold=0.8)
+        hook.record_usage(output_tokens=90)
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_no_degrade_below_threshold(self):
+        hook = TokenBudgetHook(max_output_tokens=100, degrade_threshold=0.8)
+        hook.record_usage(output_tokens=79)
+        assert hook.before_llm_call(CTX) is None
+
+    def test_degrade_threshold_1_disables_degrade(self):
+        hook = TokenBudgetHook(max_output_tokens=100, degrade_threshold=1.0)
+        hook.record_usage(output_tokens=99)
+        assert hook.before_llm_call(CTX) is None
+        hook.record_usage(output_tokens=1)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+
+class TestTokenBudgetTotal:
+    """max_total_tokens tests."""
+
+    def test_total_halt(self):
+        hook = TokenBudgetHook(max_output_tokens=1000, max_total_tokens=200)
+        hook.record_usage(output_tokens=50, input_tokens=150)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_total_degrade(self):
+        hook = TokenBudgetHook(
+            max_output_tokens=1000, max_total_tokens=200, degrade_threshold=0.8
+        )
+        hook.record_usage(output_tokens=50, input_tokens=110)
+        assert hook.before_llm_call(CTX) is Decision.DEGRADE
+
+    def test_total_disabled_when_zero(self):
+        hook = TokenBudgetHook(max_output_tokens=1000, max_total_tokens=0)
+        hook.record_usage(output_tokens=50, input_tokens=999999)
+        assert hook.before_llm_call(CTX) is None
+
+
+class TestTokenBudgetBoundary:
+    def test_zero_max_always_halts(self):
+        hook = TokenBudgetHook(max_output_tokens=0)
+        assert hook.before_llm_call(CTX) is Decision.HALT
+
+    def test_properties_reflect_usage(self):
+        hook = TokenBudgetHook(max_output_tokens=1000)
+        hook.record_usage(output_tokens=100, input_tokens=200)
+        assert hook.output_total == 100
+        assert hook.input_total == 200
+        assert hook.total == 300
+
+
+class TestTokenBudgetProtocol:
+    def test_is_pre_dispatch(self):
+        assert isinstance(TokenBudgetHook(max_output_tokens=10), PreDispatchHook)
+
+
+class TestTokenBudgetPipelineIntegration:
+    def test_pipeline_halts_at_limit(self):
+        hook = TokenBudgetHook(max_output_tokens=100)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        assert pipe.before_llm_call(CTX) is Decision.ALLOW
+        hook.record_usage(output_tokens=100)
+        assert pipe.before_llm_call(CTX) is Decision.HALT
+
+    def test_pipeline_records_safety_event(self):
+        hook = TokenBudgetHook(max_output_tokens=100)
+        pipe = ShieldPipeline(pre_dispatch=hook)
+        hook.record_usage(output_tokens=100)
+        pipe.before_llm_call(CTX)
+        events = pipe.get_events()
+        assert len(events) == 1
+        assert events[0].event_type == "TOKEN_BUDGET_EXCEEDED"
+        assert events[0].decision is Decision.HALT
+
+
+class TestTokenBudgetConfigDefaults:
+    def test_default_disabled(self):
+        cfg = TokenBudgetConfig()
+        assert cfg.enabled is False
+
+    def test_shield_config_default_disabled(self):
+        cfg = ShieldConfig()
+        assert cfg.token_budget.enabled is False
+
+    def test_shield_is_any_enabled_true_when_token_budget_on(self):
+        cfg = ShieldConfig(token_budget=TokenBudgetConfig(enabled=True))
+        assert cfg.is_any_enabled is True
+
+
+class TestTokenBudgetIntegrationWiring:
+    def test_disabled_allows_all(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        vi = VeronicaIntegration(shield=ShieldConfig())
+        for _ in range(5):
+            assert vi._shield_pipeline.before_llm_call(CTX) is Decision.ALLOW
+
+    def test_enabled_halts_at_limit(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        cfg = ShieldConfig(
+            token_budget=TokenBudgetConfig(enabled=True, max_output_tokens=100)
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        # Access the hook to record usage
+        hook = vi._shield_pipeline._pre_dispatch
+        hook.record_usage(output_tokens=100)
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.HALT
+
+    def test_safe_mode_takes_priority(self):
+        from veronica_core.integration import VeronicaIntegration
+        from veronica_core.shield.config import SafeModeConfig
+
+        cfg = ShieldConfig(
+            safe_mode=SafeModeConfig(enabled=True),
+            token_budget=TokenBudgetConfig(enabled=True, max_output_tokens=1000000),
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        assert vi._shield_pipeline.before_llm_call(CTX) is Decision.HALT


### PR DESCRIPTION
## Summary
- Add `TokenBudgetHook` for cumulative token budget enforcement (DEGRADE at 80%, HALT at 100%)
- Add `TokenBudgetConfig` to `ShieldConfig` (opt-in, disabled by default)
- Wire into `VeronicaIntegration` with priority: SafeMode > TokenBudget > BudgetWindow

## Test plan
- [x] 22 new tests covering off/on, DEGRADE zone, HALT, total tokens, boundary, protocol, pipeline, config, integration wiring
- [x] All 356 tests pass (334 existing + 22 new)

Generated with [Claude Code](https://claude.com/claude-code)