### PR TITLE
feat(policy): add MinimalResponsePolicy (opt-in)

### DIFF
--- a/src/veronica_core/policies/__init__.py
+++ b/src/veronica_core/policies/__init__.py
@@ -1,0 +1,4 @@
+"""VERONICA Runtime Policies."""
+from veronica_core.policies.minimal_response import MinimalResponsePolicy
+
+__all__ = ["MinimalResponsePolicy"]

--- a/src/veronica_core/policies/minimal_response.py
+++ b/src/veronica_core/policies/minimal_response.py
@@ -1,0 +1,109 @@
+"""MinimalResponsePolicy for VERONICA.
+
+Injects response-constraint instructions into system messages to enforce
+concise, structured output from LLM calls.  Operates as a message modifier,
+not a shield hook -- it does not block calls, only shapes them.
+
+Opt-in and disabled by default.  When disabled, all methods return inputs
+unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from veronica_core.shield.event import SafetyEvent
+from veronica_core.shield.types import Decision
+
+
+_CONSTRAINT_TEMPLATE = (
+    "\n\n--- RESPONSE CONSTRAINTS (enforced by VERONICA MinimalResponsePolicy) ---\n"
+    "- Answer in 1 line (conclusion first).\n"
+    "- Use at most {max_bullets} bullet points if elaboration needed.\n"
+    "- If uncertain, state 'uncertain' in 1 line + suggest 1 next action.\n"
+    "- {question_rule}\n"
+    "--- END CONSTRAINTS ---"
+)
+
+
+@dataclass
+class MinimalResponsePolicy:
+    """Injects conciseness constraints into system messages.
+
+    When enabled, appends structured constraint text to system messages.
+    The original message is always preserved (constraints are appended).
+
+    Attributes:
+        enabled: Whether the policy is active. Default False.
+        max_bullets: Maximum bullet points allowed. Default 5.
+        allow_questions: Whether follow-up questions are permitted. Default False.
+        max_questions: Maximum questions if allowed. Default 1.
+    """
+
+    enabled: bool = False
+    max_bullets: int = 5
+    allow_questions: bool = False
+    max_questions: int = 1
+
+    def _build_constraints(self) -> str:
+        """Build the constraint text block."""
+        if self.allow_questions:
+            question_rule = f"At most {self.max_questions} question if essential."
+        else:
+            question_rule = "No follow-up questions."
+        return _CONSTRAINT_TEMPLATE.format(
+            max_bullets=self.max_bullets,
+            question_rule=question_rule,
+        )
+
+    def inject(self, system_message: str) -> str:
+        """Append constraint text to a system message.
+
+        Args:
+            system_message: Original system message content.
+
+        Returns:
+            Original message with constraints appended (if enabled),
+            or the original message unchanged (if disabled).
+        """
+        if not self.enabled:
+            return system_message
+        return system_message + self._build_constraints()
+
+    def wrap_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Inject policy into a request dict.
+
+        Looks for a 'system' key and applies inject().
+        Preserves the original system message in '_original_system'
+        for audit purposes.
+
+        Args:
+            request: Request dict (must contain 'system' key to be modified).
+
+        Returns:
+            New dict with modified 'system' and preserved '_original_system'.
+            If disabled or no 'system' key, returns the input unchanged.
+        """
+        if not self.enabled:
+            return request
+        if "system" not in request:
+            return request
+        result = dict(request)
+        result["_original_system"] = request["system"]
+        result["system"] = self.inject(request["system"])
+        return result
+
+    def create_event(self, request_id: str | None = None) -> SafetyEvent:
+        """Create a SafetyEvent recording that this policy was applied.
+
+        Always returns an event -- caller decides whether to record it
+        (typically only when enabled).
+        """
+        return SafetyEvent(
+            event_type="POLICY_APPLIED",
+            decision=Decision.ALLOW,
+            reason="minimal_response_policy applied",
+            hook="MinimalResponsePolicy",
+            request_id=request_id,
+        )

--- a/tests/test_minimal_response_policy.py
+++ b/tests/test_minimal_response_policy.py
@@ -1,0 +1,114 @@
+"""Tests for MinimalResponsePolicy."""
+
+from __future__ import annotations
+
+import pytest
+
+from veronica_core.policies.minimal_response import MinimalResponsePolicy
+from veronica_core.shield.types import Decision
+
+
+class TestMinimalResponseDisabled:
+    """When disabled, all methods return inputs unchanged."""
+
+    def test_inject_returns_original(self):
+        policy = MinimalResponsePolicy(enabled=False)
+        msg = "You are a helpful assistant."
+        assert policy.inject(msg) is msg
+
+    def test_wrap_request_returns_original(self):
+        policy = MinimalResponsePolicy(enabled=False)
+        req = {"system": "Hello", "model": "gpt-4"}
+        result = policy.wrap_request(req)
+        assert result is req
+        assert "_original_system" not in result
+
+
+class TestMinimalResponseEnabled:
+    """When enabled, constraints are injected."""
+
+    def test_inject_appends_constraints(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        msg = "You are a helpful assistant."
+        result = policy.inject(msg)
+        assert result.startswith(msg)
+        assert "RESPONSE CONSTRAINTS" in result
+        assert "VERONICA MinimalResponsePolicy" in result
+
+    def test_inject_contains_bullet_limit(self):
+        policy = MinimalResponsePolicy(enabled=True, max_bullets=3)
+        result = policy.inject("test")
+        assert "at most 3 bullet points" in result
+
+    def test_inject_no_questions_by_default(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        result = policy.inject("test")
+        assert "No follow-up questions." in result
+
+    def test_inject_allows_questions_when_configured(self):
+        policy = MinimalResponsePolicy(enabled=True, allow_questions=True, max_questions=2)
+        result = policy.inject("test")
+        assert "At most 2 question" in result
+
+    def test_inject_default_max_bullets_is_5(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        result = policy.inject("test")
+        assert "at most 5 bullet points" in result
+
+
+class TestWrapRequest:
+    """wrap_request preserves original and modifies system."""
+
+    def test_preserves_original_system(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        req = {"system": "Original prompt", "model": "gpt-4"}
+        result = policy.wrap_request(req)
+        assert result["_original_system"] == "Original prompt"
+        assert "RESPONSE CONSTRAINTS" in result["system"]
+        assert result["model"] == "gpt-4"
+
+    def test_does_not_mutate_input(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        req = {"system": "Original"}
+        result = policy.wrap_request(req)
+        assert req.get("_original_system") is None  # Input not mutated
+
+    def test_missing_system_key_returns_unchanged(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        req = {"model": "gpt-4", "prompt": "Hello"}
+        result = policy.wrap_request(req)
+        assert result is req
+
+
+class TestCreateEvent:
+    """create_event returns correct SafetyEvent."""
+
+    def test_event_type_is_policy_applied(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        event = policy.create_event(request_id="req-1")
+        assert event.event_type == "POLICY_APPLIED"
+        assert event.decision is Decision.ALLOW
+        assert event.reason == "minimal_response_policy applied"
+        assert event.hook == "MinimalResponsePolicy"
+        assert event.request_id == "req-1"
+
+    def test_event_without_request_id(self):
+        policy = MinimalResponsePolicy()
+        event = policy.create_event()
+        assert event.request_id is None
+
+
+class TestEdgeCases:
+    """Edge cases for robustness."""
+
+    def test_empty_system_message(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        result = policy.inject("")
+        assert "RESPONSE CONSTRAINTS" in result
+
+    def test_very_long_system_message(self):
+        policy = MinimalResponsePolicy(enabled=True)
+        long_msg = "x" * 100_000
+        result = policy.inject(long_msg)
+        assert result.startswith(long_msg)
+        assert "RESPONSE CONSTRAINTS" in result


### PR DESCRIPTION
## Summary
- Add `MinimalResponsePolicy` dataclass for injecting conciseness constraints into system messages
- Supports configurable bullet limits, question rules, and audit trail (`_original_system` preservation)
- Creates `SafetyEvent` with `POLICY_APPLIED` type for evidence recording

## Test plan
- [x] 14 new tests covering disabled/enabled, injection, wrap_request, create_event, edge cases
- [x] All 370 tests pass (356 existing + 14 new)

Generated with [Claude Code](https://claude.com/claude-code)