### PR TITLE
ci: add PyPI auto-publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check distribution
+        run: twine check dist/*
+
+      - name: Publish to PyPI
+        if: "!contains(github.event.release.tag_name, 'rc')"
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
+
+      - name: Publish to TestPyPI (release candidates)
+        if: contains(github.event.release.tag_name, 'rc')
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: twine upload --repository testpypi dist/*


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` triggered on GitHub Release
- Stable releases publish to PyPI via `PYPI_API_TOKEN` secret
- Release candidates (`rc` tags) publish to TestPyPI via `TEST_PYPI_API_TOKEN`
- Build pipeline: `python -m build` -> `twine check` -> `twine upload`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Set `PYPI_API_TOKEN` secret in repo settings before v0.5.0 release
- [ ] Test with v0.5.0 release (first auto-published version)