### PR TITLE
feat(shield): add InputCompressionHook skeleton (opt-in)

### DIFF
--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -69,9 +69,11 @@ from veronica_core.shield.config import (
     SecretGuardConfig,
     BudgetWindowConfig,
     TokenBudgetConfig,
+    InputCompressionConfig,
 )
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.token_budget import TokenBudgetHook
+from veronica_core.shield.input_compression import InputCompressionHook
 
 # Runtime Policies (v0.4.3 -- opt-in, all features disabled by default)
 from veronica_core.policies.minimal_response import MinimalResponsePolicy
@@ -123,6 +125,9 @@ __all__ = [
     "BudgetWindowHook",
     "TokenBudgetConfig",
     "TokenBudgetHook",
+    # Input Compression (v0.5.0)
+    "InputCompressionConfig",
+    "InputCompressionHook",
     # Runtime Policies (v0.4.3)
     "MinimalResponsePolicy",
 ]

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,6 +1,7 @@
 """VERONICA Execution Shield."""
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
+from veronica_core.shield.input_compression import InputCompressionHook
 from veronica_core.shield.token_budget import TokenBudgetHook
 from veronica_core.shield.errors import ShieldBlockedError
 from veronica_core.shield.event import SafetyEvent
@@ -28,5 +29,6 @@ __all__ = [
     "SafeModeHook",
     "BudgetWindowHook",
     "TokenBudgetHook",
+    "InputCompressionHook",
     "SafetyEvent",
 ]

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -76,6 +76,20 @@ class BudgetWindowConfig:
 
 
 @dataclass
+class InputCompressionConfig:
+    """Input compression gate (opt-in).
+
+    Disabled by default.  When enabled, ``check_input()`` returns DEGRADE
+    when estimated tokens exceed ``compression_threshold_tokens`` and HALT
+    at ``halt_threshold_tokens``.  No actual compression -- skeleton only.
+    """
+
+    enabled: bool = False
+    compression_threshold_tokens: int = 4000
+    halt_threshold_tokens: int = 8000
+
+
+@dataclass
 class TokenBudgetConfig:
     """Token-based budget limiter (opt-in).
 
@@ -105,6 +119,7 @@ class ShieldConfig:
     secret_guard: SecretGuardConfig = field(default_factory=SecretGuardConfig)
     budget_window: BudgetWindowConfig = field(default_factory=BudgetWindowConfig)
     token_budget: TokenBudgetConfig = field(default_factory=TokenBudgetConfig)
+    input_compression: InputCompressionConfig = field(default_factory=InputCompressionConfig)
 
     @property
     def is_any_enabled(self) -> bool:
@@ -117,6 +132,7 @@ class ShieldConfig:
             self.secret_guard.enabled,
             self.budget_window.enabled,
             self.token_budget.enabled,
+            self.input_compression.enabled,
         ])
 
     def to_dict(self) -> dict:
@@ -134,6 +150,7 @@ class ShieldConfig:
             secret_guard=SecretGuardConfig(**data.get("secret_guard", {})),
             budget_window=BudgetWindowConfig(**data.get("budget_window", {})),
             token_budget=TokenBudgetConfig(**data.get("token_budget", {})),
+            input_compression=InputCompressionConfig(**data.get("input_compression", {})),
         )
 
     @classmethod

--- a/src/veronica_core/shield/input_compression.py
+++ b/src/veronica_core/shield/input_compression.py
@@ -1,0 +1,118 @@
+"""InputCompressionHook for VERONICA Execution Shield.
+
+Skeleton implementation: decision + evidence only, NO actual compression.
+When estimated input tokens exceed ``compression_threshold_tokens``,
+returns Decision.DEGRADE.  At ``halt_threshold_tokens``, returns Decision.HALT.
+
+Token estimation is MVP: ``len(text) / 4``.  The hook records an
+``INPUT_TOO_LARGE`` SafetyEvent with ``input_sha256`` for audit -- raw
+text is never stored.
+
+Actual compression logic is deferred to v0.5.1+.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from typing import Any
+
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count from raw text (MVP: len/4)."""
+    return len(text) // 4
+
+
+def _sha256(text: str) -> str:
+    """Return hex SHA-256 of UTF-8 encoded text."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class InputCompressionHook:
+    """Input size gate with optional DEGRADE zone.
+
+    Thread-safe.  The caller invokes ``check_input(text, ctx)`` before
+    sending the prompt to the LLM.  The hook does NOT modify the text --
+    it only returns a Decision and records evidence.
+
+    Decision logic:
+      - estimated_tokens >= halt_threshold  -> HALT
+      - estimated_tokens >= compress_threshold -> DEGRADE
+      - otherwise -> None (ALLOW)
+
+    Evidence dict (available via ``last_evidence``):
+      - estimated_tokens: int
+      - input_sha256: str
+      - decision: str
+    """
+
+    def __init__(
+        self,
+        compression_threshold_tokens: int = 4000,
+        halt_threshold_tokens: int = 8000,
+    ) -> None:
+        if halt_threshold_tokens <= compression_threshold_tokens:
+            raise ValueError(
+                f"halt_threshold_tokens ({halt_threshold_tokens}) must be "
+                f"greater than compression_threshold_tokens ({compression_threshold_tokens})"
+            )
+        self._compress_threshold = compression_threshold_tokens
+        self._halt_threshold = halt_threshold_tokens
+        self._last_evidence: dict[str, Any] | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def compression_threshold_tokens(self) -> int:
+        return self._compress_threshold
+
+    @property
+    def halt_threshold_tokens(self) -> int:
+        return self._halt_threshold
+
+    @property
+    def last_evidence(self) -> dict[str, Any] | None:
+        """Return evidence dict from the most recent non-ALLOW check."""
+        with self._lock:
+            return self._last_evidence
+
+    def check_input(self, text: str, ctx: ToolCallContext) -> Decision | None:
+        """Check input size and return a Decision.
+
+        Returns None (ALLOW) if within budget, DEGRADE or HALT otherwise.
+        """
+        tokens = estimate_tokens(text)
+
+        if tokens < self._compress_threshold:
+            return None
+
+        sha = _sha256(text)
+
+        if tokens >= self._halt_threshold:
+            decision = Decision.HALT
+        else:
+            decision = Decision.DEGRADE
+
+        evidence = {
+            "estimated_tokens": tokens,
+            "input_sha256": sha,
+            "decision": decision.value,
+            "compression_threshold": self._compress_threshold,
+            "halt_threshold": self._halt_threshold,
+        }
+
+        with self._lock:
+            self._last_evidence = evidence
+
+        return decision
+
+    def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
+        """PreDispatchHook protocol -- always ALLOW.
+
+        InputCompressionHook is NOT a pre-dispatch hook.  Callers should
+        use ``check_input()`` with the actual prompt text.  This method
+        exists only so the hook can be wired into the pipeline for future
+        use; it always returns None (ALLOW).
+        """
+        return None

--- a/src/veronica_core/shield/pipeline.py
+++ b/src/veronica_core/shield/pipeline.py
@@ -23,6 +23,7 @@ _HOOK_EVENT_TYPES: dict[str, str] = {
     "SafeModeHook": "SAFE_MODE",
     "BudgetWindowHook": "BUDGET_WINDOW_EXCEEDED",
     "TokenBudgetHook": "TOKEN_BUDGET_EXCEEDED",
+    "InputCompressionHook": "INPUT_TOO_LARGE",
     "BudgetBoundaryHook": "BUDGET_EXCEEDED",
     "EgressBoundaryHook": "EGRESS_BLOCKED",
     "RetryBoundaryHook": "RETRY_BLOCKED",

--- a/tests/test_shield_input_compression.py
+++ b/tests/test_shield_input_compression.py
@@ -1,0 +1,267 @@
+"""Tests for InputCompressionHook."""
+
+from __future__ import annotations
+
+import pytest
+
+from veronica_core.shield import (
+    Decision,
+    InputCompressionHook,
+    ToolCallContext,
+)
+from veronica_core.shield.config import InputCompressionConfig, ShieldConfig
+from veronica_core.shield.input_compression import estimate_tokens, _sha256
+from veronica_core.shield.pipeline import _HOOK_EVENT_TYPES
+
+CTX = ToolCallContext(request_id="test", tool_name="llm")
+
+
+# ---------------------------------------------------------------------------
+# estimate_tokens
+# ---------------------------------------------------------------------------
+
+class TestEstimateTokens:
+    def test_empty_string(self):
+        assert estimate_tokens("") == 0
+
+    def test_short_string(self):
+        assert estimate_tokens("hi") == 0  # 2 // 4 == 0
+
+    def test_known_length(self):
+        text = "a" * 400
+        assert estimate_tokens(text) == 100
+
+    def test_integer_division(self):
+        text = "a" * 7
+        assert estimate_tokens(text) == 1  # 7 // 4 == 1
+
+
+# ---------------------------------------------------------------------------
+# _sha256
+# ---------------------------------------------------------------------------
+
+class TestSha256:
+    def test_deterministic(self):
+        assert _sha256("hello") == _sha256("hello")
+
+    def test_different_input(self):
+        assert _sha256("hello") != _sha256("world")
+
+    def test_hex_length(self):
+        assert len(_sha256("test")) == 64
+
+
+# ---------------------------------------------------------------------------
+# InputCompressionHook — basic
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionBasic:
+    def test_allow_below_threshold(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 100  # 25 tokens
+        assert hook.check_input(text, CTX) is None
+
+    def test_degrade_at_threshold(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 400  # 100 tokens
+        assert hook.check_input(text, CTX) is Decision.DEGRADE
+
+    def test_degrade_between_thresholds(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 600  # 150 tokens
+        assert hook.check_input(text, CTX) is Decision.DEGRADE
+
+    def test_halt_at_halt_threshold(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 800  # 200 tokens
+        assert hook.check_input(text, CTX) is Decision.HALT
+
+    def test_halt_above_halt_threshold(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 1200  # 300 tokens
+        assert hook.check_input(text, CTX) is Decision.HALT
+
+
+# ---------------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionEvidence:
+    def test_no_evidence_when_allow(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        hook.check_input("short", CTX)
+        assert hook.last_evidence is None
+
+    def test_evidence_on_degrade(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 400
+        hook.check_input(text, CTX)
+        ev = hook.last_evidence
+        assert ev is not None
+        assert ev["estimated_tokens"] == 100
+        assert ev["decision"] == "DEGRADE"
+        assert len(ev["input_sha256"]) == 64
+
+    def test_evidence_on_halt(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 800
+        hook.check_input(text, CTX)
+        ev = hook.last_evidence
+        assert ev is not None
+        assert ev["decision"] == "HALT"
+        assert ev["compression_threshold"] == 100
+        assert ev["halt_threshold"] == 200
+
+    def test_evidence_contains_sha256(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=20
+        )
+        text = "a" * 100
+        hook.check_input(text, CTX)
+        ev = hook.last_evidence
+        assert ev["input_sha256"] == _sha256(text)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionValidation:
+    def test_halt_must_exceed_compress(self):
+        with pytest.raises(ValueError, match="must be greater"):
+            InputCompressionHook(
+                compression_threshold_tokens=100, halt_threshold_tokens=100
+            )
+
+    def test_halt_less_than_compress_raises(self):
+        with pytest.raises(ValueError, match="must be greater"):
+            InputCompressionHook(
+                compression_threshold_tokens=200, halt_threshold_tokens=100
+            )
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionProperties:
+    def test_threshold_properties(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=500, halt_threshold_tokens=1000
+        )
+        assert hook.compression_threshold_tokens == 500
+        assert hook.halt_threshold_tokens == 1000
+
+
+# ---------------------------------------------------------------------------
+# before_llm_call (passthrough)
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionPreDispatch:
+    def test_before_llm_call_always_none(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=20
+        )
+        assert hook.before_llm_call(CTX) is None
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionConfig:
+    def test_default_disabled(self):
+        cfg = InputCompressionConfig()
+        assert cfg.enabled is False
+
+    def test_shield_config_default_disabled(self):
+        cfg = ShieldConfig()
+        assert cfg.input_compression.enabled is False
+
+    def test_shield_is_any_enabled_true(self):
+        cfg = ShieldConfig(
+            input_compression=InputCompressionConfig(enabled=True)
+        )
+        assert cfg.is_any_enabled is True
+
+    def test_from_dict_round_trip(self):
+        cfg = ShieldConfig(
+            input_compression=InputCompressionConfig(
+                enabled=True,
+                compression_threshold_tokens=2000,
+                halt_threshold_tokens=5000,
+            )
+        )
+        d = cfg.to_dict()
+        restored = ShieldConfig.from_dict(d)
+        assert restored.input_compression.enabled is True
+        assert restored.input_compression.compression_threshold_tokens == 2000
+        assert restored.input_compression.halt_threshold_tokens == 5000
+
+
+# ---------------------------------------------------------------------------
+# Pipeline event type
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionEventType:
+    def test_event_type_registered(self):
+        assert "InputCompressionHook" in _HOOK_EVENT_TYPES
+        assert _HOOK_EVENT_TYPES["InputCompressionHook"] == "INPUT_TOO_LARGE"
+
+
+# ---------------------------------------------------------------------------
+# Integration wiring
+# ---------------------------------------------------------------------------
+
+class TestInputCompressionIntegration:
+    def test_disabled_no_hook(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        vi = VeronicaIntegration(shield=ShieldConfig())
+        assert vi._input_compression_hook is None
+
+    def test_enabled_creates_hook(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        cfg = ShieldConfig(
+            input_compression=InputCompressionConfig(
+                enabled=True,
+                compression_threshold_tokens=500,
+                halt_threshold_tokens=1000,
+            )
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        assert vi._input_compression_hook is not None
+        assert vi._input_compression_hook.compression_threshold_tokens == 500
+        assert vi._input_compression_hook.halt_threshold_tokens == 1000
+
+    def test_hook_check_input_works(self):
+        from veronica_core.integration import VeronicaIntegration
+
+        cfg = ShieldConfig(
+            input_compression=InputCompressionConfig(
+                enabled=True,
+                compression_threshold_tokens=100,
+                halt_threshold_tokens=200,
+            )
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        hook = vi._input_compression_hook
+        text = "a" * 800  # 200 tokens -> HALT
+        assert hook.check_input(text, CTX) is Decision.HALT


### PR DESCRIPTION
## Summary
- Adds `InputCompressionHook` -- decision + evidence only, NO actual compression
- `check_input(text, ctx)` returns DEGRADE at threshold, HALT at ceiling
- Token estimation: `len(text) // 4` (MVP)
- Records evidence with `input_sha256` for audit (raw text never stored)
- `InputCompressionConfig` added to `ShieldConfig` (disabled by default)
- Integration wiring via `VeronicaIntegration._input_compression_hook`
- Actual compression logic deferred to v0.5.1+

## Test plan
- [x] 28 new tests covering: estimate_tokens, sha256, ALLOW/DEGRADE/HALT, evidence, validation, config, pipeline event type, integration wiring
- [x] Full suite: 398 passed, 4 xfailed