### PR TITLE
release: v0.5.0 (input compression skeleton + PyPI auto-publish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,18 @@ If the agent spirals, `BudgetExceeded` is raised **before** the call reaches the
 
 ---
 
-## Ship Readiness (v0.4.3)
+## Ship Readiness (v0.5.0)
 
 - [x] BudgetWindow stops runaway execution (ceiling enforced)
 - [x] SafetyEvent records structured evidence for non-ALLOW decisions
 - [x] DEGRADE supported (fallback at threshold, HALT at ceiling)
 - [x] TokenBudgetHook: cumulative output/total token ceiling with DEGRADE zone
 - [x] MinimalResponsePolicy: opt-in conciseness constraints for system messages
+- [x] InputCompressionHook: input size gate with SHA-256 evidence (skeleton -- compression in v0.5.1)
+- [x] PyPI auto-publish on GitHub Release
 - [x] Everything is opt-in & non-breaking (default behavior unchanged)
 
-Minimum production use-case supported: runaway loop/cascade containment via budget ceiling + graceful degrade + auditable events + token-level budget enforcement.
+Minimum production use-case supported: runaway loop/cascade containment via budget ceiling + graceful degrade + auditable events + token-level budget enforcement + input size detection.
 
 ---
 
@@ -106,6 +108,27 @@ python examples/token_budget_minimal_demo.py
 --- MinimalResponsePolicy demo ---
   [disabled] system message unchanged: You are a helpful assistant.
   [enabled]  system message with constraints injected
+```
+
+---
+
+## Input Compression Skeleton Demo (30 seconds)
+
+```bash
+pip install -e .
+python examples/input_compression_skeleton_demo.py
+```
+
+```
+--- InputCompressionHook demo ---
+  Short input (22 tokens)  -> ALLOW
+  Medium input (750 tokens) -> DEGRADE  (compression suggested)
+  Large input (1250 tokens)  -> HALT  (input too large)
+
+  Evidence (HALT):
+    estimated_tokens: 1250
+    input_sha256: c59d3c04...  (raw text NOT stored)
+    decision: HALT
 ```
 
 ---

--- a/examples/input_compression_skeleton_demo.py
+++ b/examples/input_compression_skeleton_demo.py
@@ -1,0 +1,44 @@
+"""Demo: InputCompressionHook skeleton (v0.5.0).
+
+Shows decision + evidence behavior without actual compression.
+Run: python examples/input_compression_skeleton_demo.py
+"""
+
+from veronica_core.shield.input_compression import InputCompressionHook, estimate_tokens
+from veronica_core.shield.types import Decision, ToolCallContext
+
+ctx = ToolCallContext(request_id="demo", tool_name="llm")
+
+hook = InputCompressionHook(
+    compression_threshold_tokens=500,
+    halt_threshold_tokens=1000,
+)
+
+print("--- InputCompressionHook demo ---")
+
+# Case 1: Short input (well below threshold)
+short_text = "What is the capital of France?" * 3  # ~90 chars -> ~22 tokens
+tokens = estimate_tokens(short_text)
+result = hook.check_input(short_text, ctx)
+label = "ALLOW" if result is None else result.value
+print(f"  Short input ({tokens} tokens)  -> {label}")
+
+# Case 2: Medium input (between compress and halt thresholds)
+medium_text = "x" * 3000  # 750 tokens -> DEGRADE
+tokens = estimate_tokens(medium_text)
+result = hook.check_input(medium_text, ctx)
+print(f"  Medium input ({tokens} tokens) -> {result.value}  (compression suggested)")
+
+# Case 3: Large input (above halt threshold)
+large_text = "x" * 5000  # 1250 tokens -> HALT
+tokens = estimate_tokens(large_text)
+result = hook.check_input(large_text, ctx)
+print(f"  Large input ({tokens} tokens)  -> {result.value}  (input too large)")
+
+# Show evidence from last non-ALLOW check
+print()
+ev = hook.last_evidence
+print("  Evidence (HALT):")
+print(f"    estimated_tokens: {ev['estimated_tokens']}")
+print(f"    input_sha256: {ev['input_sha256'][:8]}...  (raw text NOT stored)")
+print(f"    decision: {ev['decision']}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "veronica-core"
-version = "0.4.3"
+version = "0.5.0"
 description = "Enforcement hooks for LLM agent runs. Budget limits, concurrency gating, and degradation control."
 readme = "README.md"
 license = "MIT"
@@ -36,10 +36,10 @@ dev = [
 ]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/veronica"]
+include = ["src/veronica", "src/veronica_core"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/veronica"]
+packages = ["src/veronica", "src/veronica_core"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -1,6 +1,6 @@
 """VERONICA Core - Failsafe state machine for mission-critical applications."""
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 # Core state machine
 from veronica_core.state import (


### PR DESCRIPTION
## Summary
- Version bump to 0.5.0
- README Ship Readiness v0.5.0
- Input compression skeleton demo (`examples/input_compression_skeleton_demo.py`)
- Fix `pyproject.toml` build targets to include `veronica_core` package
- Build + twine check PASSED

## What's new in v0.5.0
- PR #23: PyPI auto-publish workflow (triggered on GitHub Release)
- PR #24: InputCompressionHook skeleton (decision + evidence, no actual compression)
- This PR: Version bump + README + demo + build fix

## Test plan
- [x] 398 passed, 4 xfailed
- [x] `python -m build` succeeds
- [x] `twine check dist/*` PASSED
- [x] Demo runs correctly