### PR TITLE
feat(shield): real compression for InputCompressionHook

### DIFF
--- a/src/veronica_core/integration.py
+++ b/src/veronica_core/integration.py
@@ -107,6 +107,7 @@ class VeronicaIntegration:
                     InputCompressionHook(
                         compression_threshold_tokens=shield.input_compression.compression_threshold_tokens,
                         halt_threshold_tokens=shield.input_compression.halt_threshold_tokens,
+                        fallback_to_original=shield.input_compression.fallback_to_original,
                     )
                 )
             else:

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,7 +1,11 @@
 """VERONICA Execution Shield."""
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
-from veronica_core.shield.input_compression import InputCompressionHook
+from veronica_core.shield.input_compression import (
+    Compressor,
+    InputCompressionHook,
+    TemplateCompressor,
+)
 from veronica_core.shield.token_budget import TokenBudgetHook
 from veronica_core.shield.errors import ShieldBlockedError
 from veronica_core.shield.event import SafetyEvent
@@ -29,6 +33,8 @@ __all__ = [
     "SafeModeHook",
     "BudgetWindowHook",
     "TokenBudgetHook",
+    "Compressor",
     "InputCompressionHook",
+    "TemplateCompressor",
     "SafetyEvent",
 ]

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -79,14 +79,18 @@ class BudgetWindowConfig:
 class InputCompressionConfig:
     """Input compression gate (opt-in).
 
-    Disabled by default.  When enabled, ``check_input()`` returns DEGRADE
-    when estimated tokens exceed ``compression_threshold_tokens`` and HALT
-    at ``halt_threshold_tokens``.  No actual compression -- skeleton only.
+    Disabled by default.  When enabled, ``compress_if_needed()`` compresses
+    input above ``compression_threshold_tokens`` and HALTs at
+    ``halt_threshold_tokens``.
+
+    ``fallback_to_original``: if True, compression failure returns DEGRADE
+    with original text instead of HALT.
     """
 
     enabled: bool = False
     compression_threshold_tokens: int = 4000
     halt_threshold_tokens: int = 8000
+    fallback_to_original: bool = False
 
 
 @dataclass

--- a/src/veronica_core/shield/input_compression.py
+++ b/src/veronica_core/shield/input_compression.py
@@ -1,22 +1,30 @@
 """InputCompressionHook for VERONICA Execution Shield.
 
-Skeleton implementation: decision + evidence only, NO actual compression.
+v0.5.1: Real compression with safety guarantees.
+
 When estimated input tokens exceed ``compression_threshold_tokens``,
-returns Decision.DEGRADE.  At ``halt_threshold_tokens``, returns Decision.HALT.
+the hook compresses the text via a pluggable ``Compressor``.  At
+``halt_threshold_tokens`` (post-compression), returns Decision.HALT.
 
-Token estimation is MVP: ``len(text) / 4``.  The hook records an
-``INPUT_TOO_LARGE`` SafetyEvent with ``input_sha256`` for audit -- raw
-text is never stored.
+Escape hatch: set env ``VERONICA_DISABLE_COMPRESSION=1`` to skip all
+compression and fall back to the v0.5.0 detect-only behavior.
 
-Actual compression logic is deferred to v0.5.1+.
+Design principles:
+  - Raw text is NEVER stored (SHA-256 hash only)
+  - Compression preserves: numbers, dates, explicit constraints
+  - Two SafetyEvents per compression: INPUT_COMPRESSED + COMPRESSION_APPLIED
+  - Failure default: HALT (configurable to fallback_to_original)
 """
 
 from __future__ import annotations
 
 import hashlib
+import os
+import re
 import threading
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
+from veronica_core.shield.event import SafetyEvent
 from veronica_core.shield.types import Decision, ToolCallContext
 
 
@@ -30,28 +38,143 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+# ---------------------------------------------------------------------------
+# Compressor Protocol + Default Implementation
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class Compressor(Protocol):
+    """Protocol for text compression strategies."""
+
+    def compress(self, text: str, target_tokens: int) -> str:
+        """Compress text to fit within target_tokens.
+
+        Must preserve: numbers, dates, explicit constraints.
+        Returns compressed text. Raises on failure.
+        """
+        ...
+
+
+# Regex patterns for "must not delete" content
+_NUMBER_RE = re.compile(r"\b\d[\d,.]*\b")
+_DATE_RE = re.compile(
+    r"\b\d{4}[-/]\d{1,2}[-/]\d{1,2}\b"
+    r"|\b\d{1,2}[-/]\d{1,2}[-/]\d{2,4}\b"
+)
+_CONSTRAINT_RE = re.compile(
+    r"(?i)\b(?:must|shall|required|mandatory|never|always|do not|don't|forbidden"
+    r"|prohibited|constraint|limit|maximum|minimum|at least|at most|no more than)\b"
+)
+
+_COMPRESSION_TEMPLATE = (
+    "=== COMPRESSED INPUT (VERONICA) ===\n"
+    "[Purpose]\n{purpose}\n\n"
+    "[Constraints]\n{constraints}\n\n"
+    "[Key Data]\n{key_data}\n\n"
+    "[Uncertainties]\n{uncertainties}\n"
+    "=== END COMPRESSED ==="
+)
+
+
+def _extract_important_lines(text: str) -> tuple[list[str], list[str]]:
+    """Split lines into (important, other).
+
+    Important = contains numbers, dates, or constraint keywords.
+    """
+    important: list[str] = []
+    other: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if (_NUMBER_RE.search(stripped)
+                or _DATE_RE.search(stripped)
+                or _CONSTRAINT_RE.search(stripped)):
+            important.append(stripped)
+        else:
+            other.append(stripped)
+    return important, other
+
+
+class TemplateCompressor:
+    """Default compressor: rule-based extraction into template.
+
+    No LLM dependency.  Preserves lines with numbers, dates, and
+    constraint keywords.  Truncates remaining lines to fit budget.
+    """
+
+    def compress(self, text: str, target_tokens: int) -> str:
+        important, other = _extract_important_lines(text)
+
+        constraints = "\n".join(f"- {l}" for l in important if _CONSTRAINT_RE.search(l))
+        key_data = "\n".join(f"- {l}" for l in important if not _CONSTRAINT_RE.search(l))
+
+        # Purpose: first non-empty line of original (truncated)
+        lines = [l.strip() for l in text.splitlines() if l.strip()]
+        purpose_raw = lines[0] if lines else "(none)"
+        max_purpose_chars = min(200, target_tokens)
+        purpose = purpose_raw[:max_purpose_chars] + ("..." if len(purpose_raw) > max_purpose_chars else "")
+
+        # Truncate constraints / key_data to fit budget
+        budget_chars = target_tokens * 4  # reverse of estimate_tokens
+        max_section = budget_chars // 4
+        if len(constraints) > max_section:
+            constraints = constraints[:max_section] + "\n  ..."
+        if len(key_data) > max_section:
+            key_data = key_data[:max_section] + "\n  ..."
+
+        # Fill remaining budget with other lines
+        used = len(purpose) + len(constraints) + len(key_data) + 200  # template overhead
+        remaining_budget = max(0, budget_chars - used)
+
+        uncertainties_lines: list[str] = []
+        remaining_chars = 0
+        for line in other:
+            if remaining_chars + len(line) + 3 > remaining_budget:
+                break
+            uncertainties_lines.append(f"- {line}")
+            remaining_chars += len(line) + 3
+
+        result = _COMPRESSION_TEMPLATE.format(
+            purpose=purpose,
+            constraints=constraints or "(none)",
+            key_data=key_data or "(none)",
+            uncertainties="\n".join(uncertainties_lines) if uncertainties_lines else "(truncated)",
+        )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# InputCompressionHook
+# ---------------------------------------------------------------------------
+
 class InputCompressionHook:
-    """Input size gate with optional DEGRADE zone.
+    """Input compression with safety guarantees.
 
-    Thread-safe.  The caller invokes ``check_input(text, ctx)`` before
-    sending the prompt to the LLM.  The hook does NOT modify the text --
-    it only returns a Decision and records evidence.
+    Thread-safe.  The caller invokes ``compress_if_needed(text, ctx)``
+    before sending the prompt to the LLM.
 
-    Decision logic:
-      - estimated_tokens >= halt_threshold  -> HALT
-      - estimated_tokens >= compress_threshold -> DEGRADE
-      - otherwise -> None (ALLOW)
+    Workflow:
+      1. Estimate tokens
+      2. If below threshold -> return (text, None) unchanged
+      3. If compression disabled (env) -> detect-only (DEGRADE/HALT)
+      4. Compress via Compressor
+      5. Re-estimate compressed tokens
+      6. If still above halt_threshold -> HALT (or fallback)
+      7. Record SafetyEvents
 
     Evidence dict (available via ``last_evidence``):
-      - estimated_tokens: int
-      - input_sha256: str
-      - decision: str
+      - before_tokens, after_tokens, compression_ratio
+      - input_sha256
+      - decision
     """
 
     def __init__(
         self,
         compression_threshold_tokens: int = 4000,
         halt_threshold_tokens: int = 8000,
+        compressor: Compressor | None = None,
+        fallback_to_original: bool = False,
     ) -> None:
         if halt_threshold_tokens <= compression_threshold_tokens:
             raise ValueError(
@@ -60,7 +183,10 @@ class InputCompressionHook:
             )
         self._compress_threshold = compression_threshold_tokens
         self._halt_threshold = halt_threshold_tokens
+        self._compressor: Compressor = compressor or TemplateCompressor()
+        self._fallback_to_original = fallback_to_original
         self._last_evidence: dict[str, Any] | None = None
+        self._safety_events: list[SafetyEvent] = []
         self._lock = threading.Lock()
 
     @property
@@ -72,15 +198,35 @@ class InputCompressionHook:
         return self._halt_threshold
 
     @property
+    def fallback_to_original(self) -> bool:
+        return self._fallback_to_original
+
+    @property
     def last_evidence(self) -> dict[str, Any] | None:
-        """Return evidence dict from the most recent non-ALLOW check."""
+        """Return evidence dict from the most recent non-ALLOW operation."""
         with self._lock:
             return self._last_evidence
 
+    def get_events(self) -> list[SafetyEvent]:
+        """Return accumulated SafetyEvents (shallow copy)."""
+        with self._lock:
+            return list(self._safety_events)
+
+    def clear_events(self) -> None:
+        """Clear accumulated SafetyEvents."""
+        with self._lock:
+            self._safety_events.clear()
+
+    @staticmethod
+    def _is_disabled() -> bool:
+        """Check escape hatch env var."""
+        return os.environ.get("VERONICA_DISABLE_COMPRESSION") == "1"
+
     def check_input(self, text: str, ctx: ToolCallContext) -> Decision | None:
-        """Check input size and return a Decision.
+        """Legacy detect-only API (v0.5.0 compat).
 
         Returns None (ALLOW) if within budget, DEGRADE or HALT otherwise.
+        Does NOT compress.
         """
         tokens = estimate_tokens(text)
 
@@ -107,12 +253,132 @@ class InputCompressionHook:
 
         return decision
 
+    def compress_if_needed(
+        self, text: str, ctx: ToolCallContext
+    ) -> tuple[str, Decision | None]:
+        """Compress input if above threshold.  Main v0.5.1 entry point.
+
+        Returns:
+            (output_text, decision)
+            - decision is None when no action needed (ALLOW)
+            - decision is DEGRADE when compression succeeded
+            - decision is HALT when compression failed or post-compress still too large
+        """
+        before_tokens = estimate_tokens(text)
+
+        # Under threshold -> pass through
+        if before_tokens < self._compress_threshold:
+            return text, None
+
+        input_sha = _sha256(text)
+
+        # Escape hatch
+        if self._is_disabled():
+            decision = Decision.HALT if before_tokens >= self._halt_threshold else Decision.DEGRADE
+            with self._lock:
+                self._last_evidence = {
+                    "before_tokens": before_tokens,
+                    "input_sha256": input_sha,
+                    "decision": decision.value,
+                    "compression_disabled": True,
+                }
+            return text, decision
+
+        # Attempt compression
+        target_tokens = self._compress_threshold
+        try:
+            compressed = self._compressor.compress(text, target_tokens)
+        except Exception:
+            # Compression failed
+            if self._fallback_to_original:
+                decision = Decision.DEGRADE
+                self._record_events(
+                    ctx, before_tokens, before_tokens, input_sha,
+                    decision, compression_failed=True,
+                )
+                return text, decision
+            else:
+                decision = Decision.HALT
+                self._record_events(
+                    ctx, before_tokens, before_tokens, input_sha,
+                    decision, compression_failed=True,
+                )
+                return text, decision
+
+        after_tokens = estimate_tokens(compressed)
+
+        # Post-compression still above halt threshold?
+        if after_tokens >= self._halt_threshold:
+            if self._fallback_to_original:
+                decision = Decision.DEGRADE
+                self._record_events(
+                    ctx, before_tokens, after_tokens, input_sha, decision,
+                )
+                return text, decision
+            else:
+                decision = Decision.HALT
+                self._record_events(
+                    ctx, before_tokens, after_tokens, input_sha, decision,
+                )
+                return text, decision
+
+        # Compression succeeded
+        decision = Decision.DEGRADE
+        self._record_events(ctx, before_tokens, after_tokens, input_sha, decision)
+        return compressed, decision
+
+    def _record_events(
+        self,
+        ctx: ToolCallContext,
+        before_tokens: int,
+        after_tokens: int,
+        input_sha: str,
+        decision: Decision,
+        compression_failed: bool = False,
+    ) -> None:
+        """Record INPUT_COMPRESSED + COMPRESSION_APPLIED SafetyEvents."""
+        ratio = after_tokens / before_tokens if before_tokens > 0 else 1.0
+
+        evidence = {
+            "before_tokens": before_tokens,
+            "after_tokens": after_tokens,
+            "compression_ratio": round(ratio, 4),
+            "input_sha256": input_sha,
+            "decision": decision.value,
+        }
+        if compression_failed:
+            evidence["compression_failed"] = True
+
+        with self._lock:
+            self._last_evidence = evidence
+
+            self._safety_events.append(SafetyEvent(
+                event_type="INPUT_COMPRESSED",
+                decision=decision,
+                reason=f"before={before_tokens} after={after_tokens} ratio={ratio:.2%}",
+                hook="InputCompressionHook",
+                request_id=ctx.request_id,
+                metadata={
+                    "before_tokens": before_tokens,
+                    "after_tokens": after_tokens,
+                    "compression_ratio": round(ratio, 4),
+                    "input_sha256": input_sha,
+                },
+            ))
+
+            self._safety_events.append(SafetyEvent(
+                event_type="COMPRESSION_APPLIED",
+                decision=decision,
+                reason=f"compression {'failed' if compression_failed else 'applied'}",
+                hook="InputCompressionHook",
+                request_id=ctx.request_id,
+            ))
+
     def before_llm_call(self, ctx: ToolCallContext) -> Decision | None:
         """PreDispatchHook protocol -- always ALLOW.
 
         InputCompressionHook is NOT a pre-dispatch hook.  Callers should
-        use ``check_input()`` with the actual prompt text.  This method
-        exists only so the hook can be wired into the pipeline for future
-        use; it always returns None (ALLOW).
+        use ``compress_if_needed()`` or ``check_input()`` with the actual
+        prompt text.
         """
         return None

--- a/tests/test_input_compression_runtime.py
+++ b/tests/test_input_compression_runtime.py
@@ -1,0 +1,330 @@
+"""Tests for InputCompressionHook runtime compression (v0.5.1)."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from veronica_core.shield.input_compression import (
+    Compressor,
+    InputCompressionHook,
+    TemplateCompressor,
+    _extract_important_lines,
+    estimate_tokens,
+)
+from veronica_core.shield.types import Decision, ToolCallContext
+
+CTX = ToolCallContext(request_id="test-runtime", tool_name="llm")
+
+
+# ---------------------------------------------------------------------------
+# TemplateCompressor
+# ---------------------------------------------------------------------------
+
+class TestTemplateCompressor:
+    def test_compress_preserves_numbers(self):
+        tc = TemplateCompressor()
+        text = "The budget is $5000.\nSome filler text here.\nDeadline is 2026-03-01."
+        result = tc.compress(text, target_tokens=500)
+        assert "5000" in result
+        assert "2026-03-01" in result
+
+    def test_compress_preserves_constraints(self):
+        tc = TemplateCompressor()
+        text = "You must never exceed 100 calls.\nRandom other content.\nAlways validate input."
+        result = tc.compress(text, target_tokens=500)
+        assert "must" in result.lower() or "never" in result.lower()
+        assert "Always" in result or "always" in result
+
+    def test_compress_returns_template_format(self):
+        tc = TemplateCompressor()
+        text = "Purpose line.\n" + "filler " * 200
+        result = tc.compress(text, target_tokens=100)
+        assert "[Purpose]" in result
+        assert "[Constraints]" in result
+        assert "[Key Data]" in result
+        assert "=== COMPRESSED INPUT (VERONICA) ===" in result
+
+    def test_compress_reduces_size(self):
+        tc = TemplateCompressor()
+        # Multi-line input with realistic content
+        text = "\n".join([f"Line {i}: some content here" for i in range(500)])
+        result = tc.compress(text, target_tokens=500)
+        assert estimate_tokens(result) < estimate_tokens(text)
+
+
+# ---------------------------------------------------------------------------
+# _extract_important_lines
+# ---------------------------------------------------------------------------
+
+class TestExtractImportantLines:
+    def test_numbers_are_important(self):
+        imp, oth = _extract_important_lines("budget is 5000\nhello world")
+        assert any("5000" in l for l in imp)
+        assert any("hello" in l for l in oth)
+
+    def test_dates_are_important(self):
+        imp, _ = _extract_important_lines("deadline 2026-01-15\nfoo bar")
+        assert any("2026-01-15" in l for l in imp)
+
+    def test_constraints_are_important(self):
+        imp, _ = _extract_important_lines("must not exceed limit\nrandom stuff")
+        assert any("must" in l for l in imp)
+
+    def test_empty_lines_skipped(self):
+        imp, oth = _extract_important_lines("\n\n\nhello\n\n")
+        assert len(imp) + len(oth) == 1
+
+
+# ---------------------------------------------------------------------------
+# compress_if_needed -- below threshold
+# ---------------------------------------------------------------------------
+
+class TestCompressIfNeededAllow:
+    def test_short_input_passes_through(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "short"
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert out == text
+        assert decision is None
+
+    def test_no_events_when_allow(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        hook.compress_if_needed("short", CTX)
+        assert hook.get_events() == []
+
+
+# ---------------------------------------------------------------------------
+# compress_if_needed -- compression succeeds
+# ---------------------------------------------------------------------------
+
+class TestCompressIfNeededSuccess:
+    def test_compresses_above_threshold(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=500
+        )
+        text = "x " * 500  # ~250 tokens -> above 100
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert decision is Decision.DEGRADE
+        assert "COMPRESSED" in out
+
+    def test_records_two_events(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=500
+        )
+        text = "x " * 500
+        hook.compress_if_needed(text, CTX)
+        events = hook.get_events()
+        assert len(events) == 2
+        assert events[0].event_type == "INPUT_COMPRESSED"
+        assert events[1].event_type == "COMPRESSION_APPLIED"
+
+    def test_evidence_has_compression_ratio(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=5000
+        )
+        text = "\n".join([f"Line {i}: some verbose content" for i in range(500)])
+        hook.compress_if_needed(text, CTX)
+        ev = hook.last_evidence
+        assert "before_tokens" in ev
+        assert "after_tokens" in ev
+        assert "compression_ratio" in ev
+        assert ev["after_tokens"] < ev["before_tokens"]
+
+    def test_evidence_has_sha256(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=500
+        )
+        text = "budget is 5000 and must not exceed limit " * 20
+        hook.compress_if_needed(text, CTX)
+        ev = hook.last_evidence
+        assert len(ev["input_sha256"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# compress_if_needed -- compression fails
+# ---------------------------------------------------------------------------
+
+class TestCompressIfNeededFailure:
+    def test_failure_halts_by_default(self):
+        class BrokenCompressor:
+            def compress(self, text: str, target_tokens: int) -> str:
+                raise RuntimeError("boom")
+
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=200,
+            compressor=BrokenCompressor(),
+        )
+        text = "a" * 200  # 50 tokens > 10
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert decision is Decision.HALT
+
+    def test_failure_fallback_to_original(self):
+        class BrokenCompressor:
+            def compress(self, text: str, target_tokens: int) -> str:
+                raise RuntimeError("boom")
+
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=200,
+            compressor=BrokenCompressor(),
+            fallback_to_original=True,
+        )
+        text = "a" * 200
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert decision is Decision.DEGRADE
+        assert out == text  # original returned
+
+    def test_failure_records_events(self):
+        class BrokenCompressor:
+            def compress(self, text: str, target_tokens: int) -> str:
+                raise RuntimeError("boom")
+
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=200,
+            compressor=BrokenCompressor(),
+        )
+        hook.compress_if_needed("a" * 200, CTX)
+        events = hook.get_events()
+        assert len(events) == 2
+        assert events[0].metadata.get("input_sha256") is not None
+        ev = hook.last_evidence
+        assert ev["compression_failed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+
+class TestEscapeHatch:
+    def test_disabled_env_skips_compression(self, monkeypatch):
+        monkeypatch.setenv("VERONICA_DISABLE_COMPRESSION", "1")
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=200,
+        )
+        text = "a" * 200  # 50 tokens > 10
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert out == text  # NOT compressed
+        assert decision is Decision.DEGRADE
+        ev = hook.last_evidence
+        assert ev["compression_disabled"] is True
+
+    def test_enabled_env_allows_compression(self, monkeypatch):
+        monkeypatch.delenv("VERONICA_DISABLE_COMPRESSION", raising=False)
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=500,
+        )
+        text = "a" * 200
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert decision is Decision.DEGRADE
+        assert "COMPRESSED" in out
+
+
+# ---------------------------------------------------------------------------
+# Custom compressor
+# ---------------------------------------------------------------------------
+
+class TestCustomCompressor:
+    def test_custom_compressor_used(self):
+        class HalfCompressor:
+            def compress(self, text: str, target_tokens: int) -> str:
+                return text[:len(text) // 2]
+
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=500,
+            compressor=HalfCompressor(),
+        )
+        text = "abcdef" * 100  # 600 chars -> 150 tokens
+        out, decision = hook.compress_if_needed(text, CTX)
+        assert decision is Decision.DEGRADE
+        assert len(out) == 300
+
+
+# ---------------------------------------------------------------------------
+# Compressor Protocol
+# ---------------------------------------------------------------------------
+
+class TestCompressorProtocol:
+    def test_template_compressor_is_compressor(self):
+        assert isinstance(TemplateCompressor(), Compressor)
+
+    def test_custom_class_satisfies_protocol(self):
+        class MyCompressor:
+            def compress(self, text: str, target_tokens: int) -> str:
+                return text
+
+        assert isinstance(MyCompressor(), Compressor)
+
+
+# ---------------------------------------------------------------------------
+# check_input backward compat
+# ---------------------------------------------------------------------------
+
+class TestCheckInputCompat:
+    def test_check_input_still_works(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 400  # 100 tokens
+        assert hook.check_input(text, CTX) is Decision.DEGRADE
+
+    def test_check_input_halt(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=100, halt_threshold_tokens=200
+        )
+        text = "a" * 800  # 200 tokens
+        assert hook.check_input(text, CTX) is Decision.HALT
+
+
+# ---------------------------------------------------------------------------
+# clear_events
+# ---------------------------------------------------------------------------
+
+class TestClearEvents:
+    def test_clear_events(self):
+        hook = InputCompressionHook(
+            compression_threshold_tokens=10, halt_threshold_tokens=500,
+        )
+        hook.compress_if_needed("a" * 200, CTX)
+        assert len(hook.get_events()) == 2
+        hook.clear_events()
+        assert len(hook.get_events()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Config round-trip with fallback_to_original
+# ---------------------------------------------------------------------------
+
+class TestConfigFallback:
+    def test_config_round_trip(self):
+        from veronica_core.shield.config import InputCompressionConfig, ShieldConfig
+
+        cfg = ShieldConfig(
+            input_compression=InputCompressionConfig(
+                enabled=True,
+                fallback_to_original=True,
+            )
+        )
+        d = cfg.to_dict()
+        restored = ShieldConfig.from_dict(d)
+        assert restored.input_compression.fallback_to_original is True
+
+    def test_integration_wires_fallback(self):
+        from veronica_core.integration import VeronicaIntegration
+        from veronica_core.shield.config import InputCompressionConfig, ShieldConfig
+
+        cfg = ShieldConfig(
+            input_compression=InputCompressionConfig(
+                enabled=True,
+                compression_threshold_tokens=100,
+                halt_threshold_tokens=200,
+                fallback_to_original=True,
+            )
+        )
+        vi = VeronicaIntegration(shield=cfg)
+        assert vi._input_compression_hook.fallback_to_original is True


### PR DESCRIPTION
## Summary
- Compressor protocol + TemplateCompressor default (rule-based, zero LLM dependency)
- `compress_if_needed()` main entry point with 2-stage SafetyEvent recording
- Escape hatch: `VERONICA_DISABLE_COMPRESSION=1` skips all compression
- Failure: HALT by default, `fallback_to_original=True` returns original with DEGRADE

## Test plan
- [x] 27 new tests: compressor, extraction, allow/degrade/halt, failure, escape hatch, custom compressor, protocol, backward compat, config round-trip
- [x] Full suite: 425 passed, 4 xfailed