### PR TITLE
feat(shield): add AdaptiveBudgetHook

### DIFF
--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -70,10 +70,12 @@ from veronica_core.shield.config import (
     BudgetWindowConfig,
     TokenBudgetConfig,
     InputCompressionConfig,
+    AdaptiveBudgetConfig,
 )
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.token_budget import TokenBudgetHook
 from veronica_core.shield.input_compression import InputCompressionHook
+from veronica_core.shield.adaptive_budget import AdaptiveBudgetHook, AdjustmentResult
 
 # Runtime Policies (v0.4.3 -- opt-in, all features disabled by default)
 from veronica_core.policies.minimal_response import MinimalResponsePolicy
@@ -128,6 +130,10 @@ __all__ = [
     # Input Compression (v0.5.0)
     "InputCompressionConfig",
     "InputCompressionHook",
+    # Adaptive Budget (v0.6.0)
+    "AdaptiveBudgetConfig",
+    "AdaptiveBudgetHook",
+    "AdjustmentResult",
     # Runtime Policies (v0.4.3)
     "MinimalResponsePolicy",
 ]

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -1,4 +1,8 @@
 """VERONICA Execution Shield."""
+from veronica_core.shield.adaptive_budget import (
+    AdaptiveBudgetHook,
+    AdjustmentResult,
+)
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.config import ShieldConfig
 from veronica_core.shield.input_compression import (
@@ -36,5 +40,7 @@ __all__ = [
     "Compressor",
     "InputCompressionHook",
     "TemplateCompressor",
+    "AdaptiveBudgetHook",
+    "AdjustmentResult",
     "SafetyEvent",
 ]

--- a/src/veronica_core/shield/adaptive_budget.py
+++ b/src/veronica_core/shield/adaptive_budget.py
@@ -1,0 +1,285 @@
+"""AdaptiveBudgetHook for VERONICA Execution Shield.
+
+v0.6.0: Auto-adjusts budget ceiling based on recent SafetyEvent history.
+
+Observes past events in a rolling window and tightens or loosens the
+effective ceiling:
+  - >= tighten_trigger budget-exceeded events in window -> ceiling * (1 - tighten_pct)
+  - Zero DEGRADE events in window -> ceiling * (1 + loosen_pct)
+  - All adjustments clamped to +/- max_adjustment of original ceiling
+
+Records ADAPTIVE_ADJUSTMENT SafetyEvent on each non-hold adjustment.
+
+Design principles:
+  - Decoupled: does NOT wrap a hook; returns adjusted values for caller
+  - Thread-safe: all state behind a lock
+  - Deterministic: time can be injected for testing
+  - Clamped: ceiling_multiplier always in [1 - max_adjustment, 1 + max_adjustment]
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+from veronica_core.shield.event import SafetyEvent
+from veronica_core.shield.types import Decision, ToolCallContext
+
+_DEFAULT_TIGHTEN_EVENT_TYPES = frozenset({
+    "BUDGET_EXCEEDED",
+    "BUDGET_WINDOW_EXCEEDED",
+    "TOKEN_BUDGET_EXCEEDED",
+})
+
+_DEFAULT_DEGRADE_EVENT_TYPES = frozenset({
+    "BUDGET_WINDOW_EXCEEDED",
+    "TOKEN_BUDGET_EXCEEDED",
+})
+
+
+@dataclass(frozen=True)
+class AdjustmentResult:
+    """Result of an adaptive adjustment cycle."""
+
+    action: str  # "tighten", "loosen", "hold"
+    adjusted_ceiling: int
+    ceiling_multiplier: float
+    base_ceiling: int
+    tighten_events_in_window: int
+    degrade_events_in_window: int
+
+
+class AdaptiveBudgetHook:
+    """Auto-adjusts budget ceiling based on recent SafetyEvent history.
+
+    Thread-safe.  Feed events via ``feed_event()`` / ``feed_events()``,
+    then call ``adjust()`` to evaluate and apply the adjustment.
+
+    Rules:
+      - >= tighten_trigger HALT events in window  -> tighten by tighten_pct
+      - 0 DEGRADE events in window                -> loosen by loosen_pct
+      - Otherwise                                  -> hold (no change)
+      - Multiplier clamped to [1 - max_adjustment, 1 + max_adjustment]
+    """
+
+    def __init__(
+        self,
+        base_ceiling: int,
+        window_seconds: float = 1800.0,
+        tighten_trigger: int = 3,
+        tighten_pct: float = 0.10,
+        loosen_pct: float = 0.05,
+        max_adjustment: float = 0.20,
+        tighten_event_types: frozenset[str] | None = None,
+        degrade_event_types: frozenset[str] | None = None,
+    ) -> None:
+        if base_ceiling <= 0:
+            raise ValueError(
+                f"base_ceiling must be positive, got {base_ceiling}"
+            )
+        if not (0 < tighten_pct <= 1.0):
+            raise ValueError(
+                f"tighten_pct must be in (0, 1.0], got {tighten_pct}"
+            )
+        if not (0 < loosen_pct <= 1.0):
+            raise ValueError(
+                f"loosen_pct must be in (0, 1.0], got {loosen_pct}"
+            )
+        if not (0 < max_adjustment <= 1.0):
+            raise ValueError(
+                f"max_adjustment must be in (0, 1.0], got {max_adjustment}"
+            )
+
+        self._base_ceiling = base_ceiling
+        self._window_seconds = window_seconds
+        self._tighten_trigger = tighten_trigger
+        self._tighten_pct = tighten_pct
+        self._loosen_pct = loosen_pct
+        self._max_adjustment = max_adjustment
+        self._tighten_event_types = (
+            tighten_event_types or _DEFAULT_TIGHTEN_EVENT_TYPES
+        )
+        self._degrade_event_types = (
+            degrade_event_types or _DEFAULT_DEGRADE_EVENT_TYPES
+        )
+
+        self._ceiling_multiplier: float = 1.0
+        self._event_buffer: deque[tuple[float, SafetyEvent]] = deque()
+        self._safety_events: list[SafetyEvent] = []
+        self._lock = threading.Lock()
+
+    # -- Properties ----------------------------------------------------------
+
+    @property
+    def base_ceiling(self) -> int:
+        return self._base_ceiling
+
+    @property
+    def ceiling_multiplier(self) -> float:
+        with self._lock:
+            return self._ceiling_multiplier
+
+    @property
+    def adjusted_ceiling(self) -> int:
+        with self._lock:
+            return max(1, round(self._base_ceiling * self._ceiling_multiplier))
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window_seconds
+
+    # -- Event ingestion -----------------------------------------------------
+
+    def feed_event(
+        self, event: SafetyEvent, ts: float | None = None
+    ) -> None:
+        """Feed a SafetyEvent for tracking.
+
+        Args:
+            event: The SafetyEvent to track.
+            ts: Optional epoch-seconds override (for deterministic testing).
+        """
+        if ts is None:
+            ts = time.time()
+        with self._lock:
+            self._event_buffer.append((ts, event))
+
+    def feed_events(self, events: list[SafetyEvent]) -> None:
+        """Feed multiple SafetyEvents (all stamped at current time)."""
+        now = time.time()
+        with self._lock:
+            for event in events:
+                self._event_buffer.append((now, event))
+
+    # -- Adjustment ----------------------------------------------------------
+
+    def adjust(
+        self,
+        ctx: ToolCallContext | None = None,
+        *,
+        _now: float | None = None,
+    ) -> AdjustmentResult:
+        """Analyze recent events and compute adjusted ceiling.
+
+        The ceiling_multiplier is updated in-place.  An
+        ADAPTIVE_ADJUSTMENT SafetyEvent is recorded for tighten/loosen.
+
+        Args:
+            ctx: Optional context for the SafetyEvent request_id.
+            _now: Injected timestamp for deterministic testing.
+
+        Returns:
+            AdjustmentResult describing the action taken.
+        """
+        now = _now if _now is not None else time.time()
+        cutoff = now - self._window_seconds
+
+        with self._lock:
+            # Prune expired events
+            while self._event_buffer and self._event_buffer[0][0] <= cutoff:
+                self._event_buffer.popleft()
+
+            # Count relevant events
+            tighten_count = 0
+            degrade_count = 0
+            for _, event in self._event_buffer:
+                if (
+                    event.event_type in self._tighten_event_types
+                    and event.decision == Decision.HALT
+                ):
+                    tighten_count += 1
+                if (
+                    event.event_type in self._degrade_event_types
+                    and event.decision == Decision.DEGRADE
+                ):
+                    degrade_count += 1
+
+            # Compute bounds
+            min_mult = 1.0 - self._max_adjustment
+            max_mult = 1.0 + self._max_adjustment
+            old_multiplier = self._ceiling_multiplier
+
+            # Apply rule
+            if tighten_count >= self._tighten_trigger:
+                self._ceiling_multiplier = max(
+                    min_mult,
+                    self._ceiling_multiplier - self._tighten_pct,
+                )
+                action = "tighten"
+            elif degrade_count == 0:
+                self._ceiling_multiplier = min(
+                    max_mult,
+                    self._ceiling_multiplier + self._loosen_pct,
+                )
+                action = "loosen"
+            else:
+                action = "hold"
+
+            adjusted = max(1, round(self._base_ceiling * self._ceiling_multiplier))
+
+            result = AdjustmentResult(
+                action=action,
+                adjusted_ceiling=adjusted,
+                ceiling_multiplier=round(self._ceiling_multiplier, 4),
+                base_ceiling=self._base_ceiling,
+                tighten_events_in_window=tighten_count,
+                degrade_events_in_window=degrade_count,
+            )
+
+            # Record event for non-hold
+            if action != "hold":
+                request_id = ctx.request_id if ctx else None
+                self._safety_events.append(
+                    SafetyEvent(
+                        event_type="ADAPTIVE_ADJUSTMENT",
+                        decision=(
+                            Decision.DEGRADE
+                            if action == "tighten"
+                            else Decision.ALLOW
+                        ),
+                        reason=(
+                            f"{action}: multiplier "
+                            f"{old_multiplier:.4f} -> "
+                            f"{self._ceiling_multiplier:.4f}, "
+                            f"ceiling {self._base_ceiling} -> {adjusted}, "
+                            f"exceeded={tighten_count} degrade={degrade_count}"
+                        ),
+                        hook="AdaptiveBudgetHook",
+                        request_id=request_id,
+                        metadata={
+                            "action": action,
+                            "old_multiplier": round(old_multiplier, 4),
+                            "new_multiplier": round(
+                                self._ceiling_multiplier, 4
+                            ),
+                            "adjusted_ceiling": adjusted,
+                            "base_ceiling": self._base_ceiling,
+                            "tighten_events": tighten_count,
+                            "degrade_events": degrade_count,
+                        },
+                    )
+                )
+
+            return result
+
+    # -- Event access --------------------------------------------------------
+
+    def get_events(self) -> list[SafetyEvent]:
+        """Return accumulated ADAPTIVE_ADJUSTMENT events (shallow copy)."""
+        with self._lock:
+            return list(self._safety_events)
+
+    def clear_events(self) -> None:
+        """Clear accumulated ADAPTIVE_ADJUSTMENT events."""
+        with self._lock:
+            self._safety_events.clear()
+
+    def reset(self) -> None:
+        """Reset multiplier to 1.0 and clear all state."""
+        with self._lock:
+            self._ceiling_multiplier = 1.0
+            self._event_buffer.clear()
+            self._safety_events.clear()

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -109,6 +109,26 @@ class TokenBudgetConfig:
 
 
 @dataclass
+class AdaptiveBudgetConfig:
+    """Adaptive budget auto-adjustment (opt-in).
+
+    When enabled, monitors SafetyEvents and auto-adjusts budget ceiling
+    within +/- ``max_adjustment_pct`` of the base value.
+
+    Rules:
+      - >= ``tighten_trigger`` HALT events in window -> ceiling * (1 - tighten_pct)
+      - Zero DEGRADE events in window -> ceiling * (1 + loosen_pct)
+    """
+
+    enabled: bool = False
+    window_seconds: float = 1800.0
+    tighten_trigger: int = 3
+    tighten_pct: float = 0.10
+    loosen_pct: float = 0.05
+    max_adjustment_pct: float = 0.20
+
+
+@dataclass
 class ShieldConfig:
     """Top-level shield configuration.
 
@@ -124,6 +144,7 @@ class ShieldConfig:
     budget_window: BudgetWindowConfig = field(default_factory=BudgetWindowConfig)
     token_budget: TokenBudgetConfig = field(default_factory=TokenBudgetConfig)
     input_compression: InputCompressionConfig = field(default_factory=InputCompressionConfig)
+    adaptive_budget: AdaptiveBudgetConfig = field(default_factory=AdaptiveBudgetConfig)
 
     @property
     def is_any_enabled(self) -> bool:
@@ -137,6 +158,7 @@ class ShieldConfig:
             self.budget_window.enabled,
             self.token_budget.enabled,
             self.input_compression.enabled,
+            self.adaptive_budget.enabled,
         ])
 
     def to_dict(self) -> dict:
@@ -155,6 +177,7 @@ class ShieldConfig:
             budget_window=BudgetWindowConfig(**data.get("budget_window", {})),
             token_budget=TokenBudgetConfig(**data.get("token_budget", {})),
             input_compression=InputCompressionConfig(**data.get("input_compression", {})),
+            adaptive_budget=AdaptiveBudgetConfig(**data.get("adaptive_budget", {})),
         )
 
     @classmethod

--- a/src/veronica_core/shield/pipeline.py
+++ b/src/veronica_core/shield/pipeline.py
@@ -24,6 +24,7 @@ _HOOK_EVENT_TYPES: dict[str, str] = {
     "BudgetWindowHook": "BUDGET_WINDOW_EXCEEDED",
     "TokenBudgetHook": "TOKEN_BUDGET_EXCEEDED",
     "InputCompressionHook": "INPUT_TOO_LARGE",
+    "AdaptiveBudgetHook": "ADAPTIVE_ADJUSTMENT",
     "BudgetBoundaryHook": "BUDGET_EXCEEDED",
     "EgressBoundaryHook": "EGRESS_BLOCKED",
     "RetryBoundaryHook": "RETRY_BLOCKED",

--- a/tests/test_adaptive_budget.py
+++ b/tests/test_adaptive_budget.py
@@ -1,0 +1,561 @@
+"""Tests for AdaptiveBudgetHook (v0.6.0)."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from veronica_core.shield.adaptive_budget import (
+    AdaptiveBudgetHook,
+    AdjustmentResult,
+)
+from veronica_core.shield.event import SafetyEvent
+from veronica_core.shield.types import Decision, ToolCallContext
+
+CTX = ToolCallContext(request_id="test-adaptive", tool_name="llm")
+
+
+def _halt_event(event_type: str = "BUDGET_WINDOW_EXCEEDED") -> SafetyEvent:
+    """Create a HALT SafetyEvent for testing."""
+    return SafetyEvent(
+        event_type=event_type,
+        decision=Decision.HALT,
+        reason="test",
+        hook="TestHook",
+    )
+
+
+def _degrade_event(event_type: str = "BUDGET_WINDOW_EXCEEDED") -> SafetyEvent:
+    """Create a DEGRADE SafetyEvent for testing."""
+    return SafetyEvent(
+        event_type=event_type,
+        decision=Decision.DEGRADE,
+        reason="test",
+        hook="TestHook",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction & validation
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_defaults(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100)
+        assert hook.base_ceiling == 100
+        assert hook.ceiling_multiplier == 1.0
+        assert hook.adjusted_ceiling == 100
+        assert hook.window_seconds == 1800.0
+
+    def test_custom_params(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=200,
+            window_seconds=600.0,
+            tighten_trigger=5,
+            tighten_pct=0.15,
+            loosen_pct=0.08,
+            max_adjustment=0.30,
+        )
+        assert hook.base_ceiling == 200
+        assert hook.window_seconds == 600.0
+
+    def test_validates_base_ceiling_positive(self):
+        with pytest.raises(ValueError, match="base_ceiling must be positive"):
+            AdaptiveBudgetHook(base_ceiling=0)
+
+    def test_validates_base_ceiling_negative(self):
+        with pytest.raises(ValueError, match="base_ceiling must be positive"):
+            AdaptiveBudgetHook(base_ceiling=-10)
+
+    def test_validates_tighten_pct(self):
+        with pytest.raises(ValueError, match="tighten_pct"):
+            AdaptiveBudgetHook(base_ceiling=100, tighten_pct=0.0)
+
+    def test_validates_loosen_pct(self):
+        with pytest.raises(ValueError, match="loosen_pct"):
+            AdaptiveBudgetHook(base_ceiling=100, loosen_pct=-0.1)
+
+    def test_validates_max_adjustment(self):
+        with pytest.raises(ValueError, match="max_adjustment"):
+            AdaptiveBudgetHook(base_ceiling=100, max_adjustment=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Event ingestion
+# ---------------------------------------------------------------------------
+
+
+class TestFeedEvents:
+    def test_feed_single_event(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100)
+        event = _halt_event()
+        hook.feed_event(event, ts=1000.0)
+        # No crash, event is buffered internally
+
+    def test_feed_multiple_events(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100)
+        events = [_halt_event() for _ in range(5)]
+        hook.feed_events(events)
+        # No crash, 5 events buffered
+
+
+# ---------------------------------------------------------------------------
+# Adjust: hold
+# ---------------------------------------------------------------------------
+
+
+class TestAdjustHold:
+    def test_hold_when_degrade_events_exist(self):
+        """Some degrade but below tighten threshold -> hold."""
+        hook = AdaptiveBudgetHook(base_ceiling=100, tighten_trigger=3)
+        # Feed 1 HALT (below trigger) + 1 DEGRADE (prevents loosen)
+        hook.feed_event(_halt_event(), ts=1000.0)
+        hook.feed_event(_degrade_event(), ts=1000.0)
+
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "hold"
+        assert result.adjusted_ceiling == 100
+        assert result.ceiling_multiplier == 1.0
+
+    def test_hold_records_no_event(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100, tighten_trigger=3)
+        hook.feed_event(_halt_event(), ts=1000.0)
+        hook.feed_event(_degrade_event(), ts=1000.0)
+        hook.adjust(_now=1000.0)
+        assert hook.get_events() == []
+
+
+# ---------------------------------------------------------------------------
+# Adjust: tighten
+# ---------------------------------------------------------------------------
+
+
+class TestAdjustTighten:
+    def test_tighten_on_exceeded_events(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, tighten_trigger=3, tighten_pct=0.10
+        )
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=1000.0)
+
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "tighten"
+        assert result.ceiling_multiplier == 0.9
+        assert result.adjusted_ceiling == 90
+
+    def test_tighten_records_degrade_event(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, tighten_trigger=3, tighten_pct=0.10
+        )
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=1000.0)
+
+        hook.adjust(CTX, _now=1000.0)
+        events = hook.get_events()
+        assert len(events) == 1
+        assert events[0].event_type == "ADAPTIVE_ADJUSTMENT"
+        assert events[0].decision == Decision.DEGRADE
+
+    def test_tighten_event_metadata(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, tighten_trigger=3, tighten_pct=0.10
+        )
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=1000.0)
+
+        hook.adjust(CTX, _now=1000.0)
+        ev = hook.get_events()[0]
+        assert ev.metadata["action"] == "tighten"
+        assert ev.metadata["old_multiplier"] == 1.0
+        assert ev.metadata["new_multiplier"] == 0.9
+        assert ev.metadata["adjusted_ceiling"] == 90
+        assert ev.metadata["tighten_events"] == 3
+        assert ev.request_id == "test-adaptive"
+
+    def test_tighten_clamp_at_min(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100,
+            tighten_trigger=1,
+            tighten_pct=0.15,
+            max_adjustment=0.20,
+        )
+        # 3 tighten cycles: 1.0 -> 0.85 -> 0.80 (clamped at 0.80)
+        for i in range(3):
+            hook.feed_event(_halt_event(), ts=1000.0 + i)
+            hook.adjust(_now=1000.0 + i)
+
+        assert hook.ceiling_multiplier == 0.80
+        assert hook.adjusted_ceiling == 80
+
+    def test_multiple_tighten_adjustments(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, tighten_trigger=3, tighten_pct=0.05
+        )
+        # First round: 3 HALT events
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=1000.0)
+        result1 = hook.adjust(_now=1000.0)
+        assert result1.ceiling_multiplier == 0.95
+
+        # Second round: 3 more HALT events (total 6 still in window)
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=1001.0)
+        result2 = hook.adjust(_now=1001.0)
+        assert result2.ceiling_multiplier == 0.90
+
+    def test_tighten_with_token_budget_exceeded(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, tighten_trigger=3, tighten_pct=0.10
+        )
+        for _ in range(3):
+            hook.feed_event(
+                _halt_event("TOKEN_BUDGET_EXCEEDED"), ts=1000.0
+            )
+
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "tighten"
+
+    def test_tighten_ignores_degrade_events_for_count(self):
+        """Only HALT events count toward tighten trigger."""
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, tighten_trigger=3, tighten_pct=0.10
+        )
+        # 2 HALT + 5 DEGRADE -> tighten_count = 2 < 3
+        for _ in range(2):
+            hook.feed_event(_halt_event(), ts=1000.0)
+        for _ in range(5):
+            hook.feed_event(_degrade_event(), ts=1000.0)
+
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "hold"  # 2 < 3 trigger
+
+
+# ---------------------------------------------------------------------------
+# Adjust: loosen
+# ---------------------------------------------------------------------------
+
+
+class TestAdjustLoosen:
+    def test_loosen_when_no_degrade(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, loosen_pct=0.05
+        )
+        # Empty window -> no degrade events -> loosen
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "loosen"
+        assert result.ceiling_multiplier == 1.05
+        assert result.adjusted_ceiling == 105
+
+    def test_loosen_records_allow_event(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100, loosen_pct=0.05)
+        hook.adjust(CTX, _now=1000.0)
+        events = hook.get_events()
+        assert len(events) == 1
+        assert events[0].event_type == "ADAPTIVE_ADJUSTMENT"
+        assert events[0].decision == Decision.ALLOW
+
+    def test_loosen_clamp_at_max(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100, loosen_pct=0.15, max_adjustment=0.20
+        )
+        # 3 loosen cycles: 1.0 -> 1.15 -> 1.20 (clamped at 1.20)
+        for i in range(3):
+            hook.adjust(_now=1000.0 + i)
+
+        assert hook.ceiling_multiplier == 1.20
+        assert hook.adjusted_ceiling == 120
+
+    def test_loosen_after_empty_window(self):
+        """No events at all -> zero degrade -> loosen."""
+        hook = AdaptiveBudgetHook(base_ceiling=100, loosen_pct=0.05)
+        result = hook.adjust(_now=5000.0)
+        assert result.action == "loosen"
+        assert result.degrade_events_in_window == 0
+
+
+# ---------------------------------------------------------------------------
+# Window expiry
+# ---------------------------------------------------------------------------
+
+
+class TestWindowExpiry:
+    def test_old_events_pruned(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100,
+            window_seconds=60.0,
+            tighten_trigger=3,
+        )
+        # Feed 3 HALT at time 0
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=0.0)
+
+        # At time 61, events are expired -> loosen (not tighten)
+        result = hook.adjust(_now=61.0)
+        assert result.action == "loosen"
+        assert result.tighten_events_in_window == 0
+
+
+# ---------------------------------------------------------------------------
+# Tighten then loosen recovery
+# ---------------------------------------------------------------------------
+
+
+class TestTightenThenLoosen:
+    def test_recovery_after_tighten(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100,
+            window_seconds=60.0,
+            tighten_trigger=3,
+            tighten_pct=0.10,
+            loosen_pct=0.05,
+        )
+        # Tighten at time 0
+        for _ in range(3):
+            hook.feed_event(_halt_event(), ts=0.0)
+        r1 = hook.adjust(_now=0.0)
+        assert r1.action == "tighten"
+        assert r1.ceiling_multiplier == 0.90
+
+        # At time 61, events expired -> loosen
+        r2 = hook.adjust(_now=61.0)
+        assert r2.action == "loosen"
+        assert r2.ceiling_multiplier == 0.95
+
+        # Another loosen
+        r3 = hook.adjust(_now=62.0)
+        assert r3.action == "loosen"
+        assert r3.ceiling_multiplier == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Custom event types
+# ---------------------------------------------------------------------------
+
+
+class TestCustomEventTypes:
+    def test_custom_tighten_types(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100,
+            tighten_trigger=2,
+            tighten_event_types=frozenset({"CUSTOM_EXCEEDED"}),
+        )
+        for _ in range(2):
+            hook.feed_event(
+                SafetyEvent(
+                    event_type="CUSTOM_EXCEEDED",
+                    decision=Decision.HALT,
+                    reason="test",
+                    hook="CustomHook",
+                ),
+                ts=1000.0,
+            )
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "tighten"
+
+    def test_custom_degrade_types(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100,
+            degrade_event_types=frozenset({"MY_DEGRADE"}),
+        )
+        hook.feed_event(
+            SafetyEvent(
+                event_type="MY_DEGRADE",
+                decision=Decision.DEGRADE,
+                reason="test",
+                hook="CustomHook",
+            ),
+            ts=1000.0,
+        )
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "hold"  # 1 degrade -> hold
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_adjusted_ceiling_never_below_one(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=1,
+            tighten_trigger=1,
+            tighten_pct=0.99,
+            max_adjustment=0.99,
+        )
+        hook.feed_event(_halt_event(), ts=1000.0)
+        result = hook.adjust(_now=1000.0)
+        assert result.adjusted_ceiling >= 1
+
+    def test_adjust_without_ctx(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100)
+        result = hook.adjust(_now=1000.0)
+        assert result.action == "loosen"
+        events = hook.get_events()
+        assert events[0].request_id is None
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+
+class TestStateManagement:
+    def test_get_events_returns_copy(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100)
+        hook.adjust(_now=1000.0)
+        events1 = hook.get_events()
+        events2 = hook.get_events()
+        assert events1 is not events2
+        assert len(events1) == len(events2)
+
+    def test_clear_events(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100)
+        hook.adjust(_now=1000.0)
+        assert len(hook.get_events()) == 1
+        hook.clear_events()
+        assert len(hook.get_events()) == 0
+
+    def test_reset(self):
+        hook = AdaptiveBudgetHook(base_ceiling=100, loosen_pct=0.10)
+        hook.adjust(_now=1000.0)  # loosen to 1.10
+        assert hook.ceiling_multiplier == 1.10
+        assert len(hook.get_events()) == 1
+
+        hook.reset()
+        assert hook.ceiling_multiplier == 1.0
+        assert hook.adjusted_ceiling == 100
+        assert len(hook.get_events()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_feed_and_adjust(self):
+        hook = AdaptiveBudgetHook(
+            base_ceiling=100,
+            tighten_trigger=10,
+            window_seconds=600.0,
+        )
+        errors: list[Exception] = []
+
+        def feed_loop():
+            try:
+                for i in range(50):
+                    hook.feed_event(_halt_event(), ts=1000.0 + i * 0.1)
+            except Exception as e:
+                errors.append(e)
+
+        def adjust_loop():
+            try:
+                for i in range(20):
+                    hook.adjust(_now=1000.0 + i * 0.5)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=feed_loop),
+            threading.Thread(target=adjust_loop),
+            threading.Thread(target=feed_loop),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Config round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRoundTrip:
+    def test_config_defaults(self):
+        from veronica_core.shield.config import AdaptiveBudgetConfig
+
+        cfg = AdaptiveBudgetConfig()
+        assert cfg.enabled is False
+        assert cfg.window_seconds == 1800.0
+        assert cfg.tighten_trigger == 3
+        assert cfg.tighten_pct == 0.10
+        assert cfg.loosen_pct == 0.05
+        assert cfg.max_adjustment_pct == 0.20
+
+    def test_shield_config_round_trip(self):
+        from veronica_core.shield.config import (
+            AdaptiveBudgetConfig,
+            ShieldConfig,
+        )
+
+        cfg = ShieldConfig(
+            adaptive_budget=AdaptiveBudgetConfig(
+                enabled=True,
+                window_seconds=900.0,
+                tighten_trigger=5,
+            )
+        )
+        d = cfg.to_dict()
+        restored = ShieldConfig.from_dict(d)
+        assert restored.adaptive_budget.enabled is True
+        assert restored.adaptive_budget.window_seconds == 900.0
+        assert restored.adaptive_budget.tighten_trigger == 5
+
+    def test_shield_config_is_any_enabled(self):
+        from veronica_core.shield.config import (
+            AdaptiveBudgetConfig,
+            ShieldConfig,
+        )
+
+        cfg = ShieldConfig(
+            adaptive_budget=AdaptiveBudgetConfig(enabled=True)
+        )
+        assert cfg.is_any_enabled is True
+
+    def test_shield_config_default_disabled(self):
+        from veronica_core.shield.config import ShieldConfig
+
+        cfg = ShieldConfig()
+        assert cfg.adaptive_budget.enabled is False
+        assert cfg.is_any_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# AdjustmentResult
+# ---------------------------------------------------------------------------
+
+
+class TestAdjustmentResult:
+    def test_result_fields(self):
+        result = AdjustmentResult(
+            action="tighten",
+            adjusted_ceiling=90,
+            ceiling_multiplier=0.9,
+            base_ceiling=100,
+            tighten_events_in_window=3,
+            degrade_events_in_window=1,
+        )
+        assert result.action == "tighten"
+        assert result.adjusted_ceiling == 90
+        assert result.ceiling_multiplier == 0.9
+        assert result.base_ceiling == 100
+        assert result.tighten_events_in_window == 3
+        assert result.degrade_events_in_window == 1
+
+    def test_result_is_frozen(self):
+        result = AdjustmentResult(
+            action="hold",
+            adjusted_ceiling=100,
+            ceiling_multiplier=1.0,
+            base_ceiling=100,
+            tighten_events_in_window=0,
+            degrade_events_in_window=0,
+        )
+        with pytest.raises(AttributeError):
+            result.action = "loosen"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- New `AdaptiveBudgetHook`: monitors SafetyEvent history in a rolling window, auto-adjusts budget ceiling
- Tighten rule: >= N HALT events in window -> reduce ceiling by configurable % (default -10%)
- Loosen rule: zero DEGRADE events in window -> increase ceiling by configurable % (default +5%)
- All adjustments clamped to +/-20% of base ceiling
- `AdaptiveBudgetConfig` added to `ShieldConfig` (opt-in, disabled by default)
- `ADAPTIVE_ADJUSTMENT` SafetyEvent recorded on each non-hold adjustment
- 38 new tests covering tighten/loosen/hold/clamp/recovery/thread-safety/config

## Test plan
- [x] 38 unit tests passing (tighten, loosen, hold, clamp, window expiry, recovery, custom event types, thread safety, config round-trip)
- [x] Full suite: 463 passed, 4 xfailed
- [x] No breaking changes to existing APIs