### PR TITLE
feat(shield): add TimeAwarePolicy

### DIFF
--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -71,11 +71,13 @@ from veronica_core.shield.config import (
     TokenBudgetConfig,
     InputCompressionConfig,
     AdaptiveBudgetConfig,
+    TimeAwarePolicyConfig,
 )
 from veronica_core.shield.budget_window import BudgetWindowHook
 from veronica_core.shield.token_budget import TokenBudgetHook
 from veronica_core.shield.input_compression import InputCompressionHook
 from veronica_core.shield.adaptive_budget import AdaptiveBudgetHook, AdjustmentResult
+from veronica_core.shield.time_policy import TimeAwarePolicy, TimeResult
 
 # Runtime Policies (v0.4.3 -- opt-in, all features disabled by default)
 from veronica_core.policies.minimal_response import MinimalResponsePolicy
@@ -134,6 +136,10 @@ __all__ = [
     "AdaptiveBudgetConfig",
     "AdaptiveBudgetHook",
     "AdjustmentResult",
+    # Time-Aware Policy (v0.6.0)
+    "TimeAwarePolicyConfig",
+    "TimeAwarePolicy",
+    "TimeResult",
     # Runtime Policies (v0.4.3)
     "MinimalResponsePolicy",
 ]

--- a/src/veronica_core/shield/__init__.py
+++ b/src/veronica_core/shield/__init__.py
@@ -10,6 +10,7 @@ from veronica_core.shield.input_compression import (
     InputCompressionHook,
     TemplateCompressor,
 )
+from veronica_core.shield.time_policy import TimeAwarePolicy, TimeResult
 from veronica_core.shield.token_budget import TokenBudgetHook
 from veronica_core.shield.errors import ShieldBlockedError
 from veronica_core.shield.event import SafetyEvent
@@ -42,5 +43,7 @@ __all__ = [
     "TemplateCompressor",
     "AdaptiveBudgetHook",
     "AdjustmentResult",
+    "TimeAwarePolicy",
+    "TimeResult",
     "SafetyEvent",
 ]

--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -129,6 +129,24 @@ class AdaptiveBudgetConfig:
 
 
 @dataclass
+class TimeAwarePolicyConfig:
+    """Time-aware budget multiplier (opt-in).
+
+    When enabled, reduces budget ceilings during weekends and off-hours.
+    ``weekend_multiplier`` and ``offhour_multiplier`` are applied as
+    fractions of the base ceiling.  Work hours default to 09:00-18:00 UTC.
+    """
+
+    enabled: bool = False
+    weekend_multiplier: float = 0.85
+    offhour_multiplier: float = 0.90
+    work_start_hour: int = 9
+    work_start_minute: int = 0
+    work_end_hour: int = 18
+    work_end_minute: int = 0
+
+
+@dataclass
 class ShieldConfig:
     """Top-level shield configuration.
 
@@ -145,6 +163,7 @@ class ShieldConfig:
     token_budget: TokenBudgetConfig = field(default_factory=TokenBudgetConfig)
     input_compression: InputCompressionConfig = field(default_factory=InputCompressionConfig)
     adaptive_budget: AdaptiveBudgetConfig = field(default_factory=AdaptiveBudgetConfig)
+    time_aware_policy: TimeAwarePolicyConfig = field(default_factory=TimeAwarePolicyConfig)
 
     @property
     def is_any_enabled(self) -> bool:
@@ -159,6 +178,7 @@ class ShieldConfig:
             self.token_budget.enabled,
             self.input_compression.enabled,
             self.adaptive_budget.enabled,
+            self.time_aware_policy.enabled,
         ])
 
     def to_dict(self) -> dict:
@@ -178,6 +198,7 @@ class ShieldConfig:
             token_budget=TokenBudgetConfig(**data.get("token_budget", {})),
             input_compression=InputCompressionConfig(**data.get("input_compression", {})),
             adaptive_budget=AdaptiveBudgetConfig(**data.get("adaptive_budget", {})),
+            time_aware_policy=TimeAwarePolicyConfig(**data.get("time_aware_policy", {})),
         )
 
     @classmethod

--- a/src/veronica_core/shield/pipeline.py
+++ b/src/veronica_core/shield/pipeline.py
@@ -25,6 +25,7 @@ _HOOK_EVENT_TYPES: dict[str, str] = {
     "TokenBudgetHook": "TOKEN_BUDGET_EXCEEDED",
     "InputCompressionHook": "INPUT_TOO_LARGE",
     "AdaptiveBudgetHook": "ADAPTIVE_ADJUSTMENT",
+    "TimeAwarePolicy": "TIME_POLICY_APPLIED",
     "BudgetBoundaryHook": "BUDGET_EXCEEDED",
     "EgressBoundaryHook": "EGRESS_BLOCKED",
     "RetryBoundaryHook": "RETRY_BLOCKED",

--- a/src/veronica_core/shield/time_policy.py
+++ b/src/veronica_core/shield/time_policy.py
@@ -1,0 +1,210 @@
+"""TimeAwarePolicy for VERONICA Execution Shield.
+
+v0.6.0: Multiplies budget ceilings based on time-of-day and day-of-week.
+
+Weekend and off-hours get reduced budget ceilings (configurable multipliers).
+Records TIME_POLICY_APPLIED SafetyEvent when a multiplier is active.
+
+Design principles:
+  - Pure function: given a datetime, returns the multiplier
+  - No side effects on other hooks; caller applies the multiplier
+  - Thread-safe
+  - Deterministic: accepts injected datetime for testing
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, time, timezone
+from typing import Any
+
+from veronica_core.shield.event import SafetyEvent
+from veronica_core.shield.types import Decision, ToolCallContext
+
+
+class TimeAwarePolicy:
+    """Computes budget multiplier based on time-of-day and day-of-week.
+
+    Thread-safe.  Call ``evaluate()`` to get the current multiplier and
+    optional SafetyEvent.
+
+    Schedule:
+      - Weekend (Saturday/Sunday): weekend_multiplier
+      - Off-hours (before work_start or after work_end): offhour_multiplier
+      - Both weekend AND off-hours: min(weekend, offhour)
+      - Business hours on weekdays: 1.0 (no adjustment)
+
+    The multiplier is intended to be applied to a budget ceiling, e.g.::
+
+        effective_ceiling = int(base_ceiling * policy.evaluate(ctx).multiplier)
+    """
+
+    def __init__(
+        self,
+        weekend_multiplier: float = 0.85,
+        offhour_multiplier: float = 0.90,
+        work_start: time = time(9, 0),
+        work_end: time = time(18, 0),
+        tz: timezone | None = None,
+    ) -> None:
+        if not (0 < weekend_multiplier <= 1.0):
+            raise ValueError(
+                f"weekend_multiplier must be in (0, 1.0], got {weekend_multiplier}"
+            )
+        if not (0 < offhour_multiplier <= 1.0):
+            raise ValueError(
+                f"offhour_multiplier must be in (0, 1.0], got {offhour_multiplier}"
+            )
+        if work_start >= work_end:
+            raise ValueError(
+                f"work_start ({work_start}) must be before work_end ({work_end})"
+            )
+
+        self._weekend_multiplier = weekend_multiplier
+        self._offhour_multiplier = offhour_multiplier
+        self._work_start = work_start
+        self._work_end = work_end
+        self._tz = tz or timezone.utc
+        self._safety_events: list[SafetyEvent] = []
+        self._lock = threading.Lock()
+
+    # -- Properties ----------------------------------------------------------
+
+    @property
+    def weekend_multiplier(self) -> float:
+        return self._weekend_multiplier
+
+    @property
+    def offhour_multiplier(self) -> float:
+        return self._offhour_multiplier
+
+    @property
+    def work_start(self) -> time:
+        return self._work_start
+
+    @property
+    def work_end(self) -> time:
+        return self._work_end
+
+    # -- Evaluation ----------------------------------------------------------
+
+    def get_multiplier(self, dt: datetime | None = None) -> float:
+        """Return the budget multiplier for the given datetime.
+
+        Args:
+            dt: Datetime to evaluate.  Defaults to now in configured tz.
+
+        Returns:
+            Float in (0, 1.0].  1.0 = no reduction (business hours).
+        """
+        if dt is None:
+            dt = datetime.now(self._tz)
+
+        is_weekend = dt.weekday() >= 5  # Saturday=5, Sunday=6
+        current_time = dt.time()
+        is_offhour = current_time < self._work_start or current_time >= self._work_end
+
+        if is_weekend and is_offhour:
+            return min(self._weekend_multiplier, self._offhour_multiplier)
+        if is_weekend:
+            return self._weekend_multiplier
+        if is_offhour:
+            return self._offhour_multiplier
+        return 1.0
+
+    def evaluate(
+        self,
+        ctx: ToolCallContext | None = None,
+        *,
+        dt: datetime | None = None,
+    ) -> TimeResult:
+        """Evaluate policy and record SafetyEvent if multiplier < 1.0.
+
+        Args:
+            ctx: Optional context for SafetyEvent request_id.
+            dt: Injected datetime for deterministic testing.
+
+        Returns:
+            TimeResult with multiplier and classification.
+        """
+        if dt is None:
+            dt = datetime.now(self._tz)
+
+        multiplier = self.get_multiplier(dt)
+        is_weekend = dt.weekday() >= 5
+        current_time = dt.time()
+        is_offhour = current_time < self._work_start or current_time >= self._work_end
+
+        if is_weekend and is_offhour:
+            classification = "weekend_offhour"
+        elif is_weekend:
+            classification = "weekend"
+        elif is_offhour:
+            classification = "offhour"
+        else:
+            classification = "business_hours"
+
+        result = TimeResult(
+            multiplier=multiplier,
+            classification=classification,
+            is_weekend=is_weekend,
+            is_offhour=is_offhour,
+        )
+
+        # Record event when multiplier reduces the budget
+        if multiplier < 1.0:
+            request_id = ctx.request_id if ctx else None
+            with self._lock:
+                self._safety_events.append(
+                    SafetyEvent(
+                        event_type="TIME_POLICY_APPLIED",
+                        decision=Decision.DEGRADE,
+                        reason=(
+                            f"{classification}: multiplier={multiplier:.2f}, "
+                            f"time={current_time.isoformat()}, "
+                            f"weekday={dt.weekday()}"
+                        ),
+                        hook="TimeAwarePolicy",
+                        request_id=request_id,
+                        metadata={
+                            "multiplier": multiplier,
+                            "classification": classification,
+                            "is_weekend": is_weekend,
+                            "is_offhour": is_offhour,
+                            "time": current_time.isoformat(),
+                            "weekday": dt.weekday(),
+                        },
+                    )
+                )
+
+        return result
+
+    # -- Event access --------------------------------------------------------
+
+    def get_events(self) -> list[SafetyEvent]:
+        """Return accumulated TIME_POLICY_APPLIED events (shallow copy)."""
+        with self._lock:
+            return list(self._safety_events)
+
+    def clear_events(self) -> None:
+        """Clear accumulated events."""
+        with self._lock:
+            self._safety_events.clear()
+
+
+class TimeResult:
+    """Result of a time-aware policy evaluation."""
+
+    __slots__ = ("multiplier", "classification", "is_weekend", "is_offhour")
+
+    def __init__(
+        self,
+        multiplier: float,
+        classification: str,
+        is_weekend: bool,
+        is_offhour: bool,
+    ) -> None:
+        self.multiplier = multiplier
+        self.classification = classification
+        self.is_weekend = is_weekend
+        self.is_offhour = is_offhour

--- a/tests/test_time_aware_policy.py
+++ b/tests/test_time_aware_policy.py
@@ -1,0 +1,372 @@
+"""Tests for TimeAwarePolicy (v0.6.0)."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, time, timezone
+
+import pytest
+
+from veronica_core.shield.time_policy import TimeAwarePolicy, TimeResult
+from veronica_core.shield.types import Decision, ToolCallContext
+
+CTX = ToolCallContext(request_id="test-time", tool_name="llm")
+
+
+def _dt(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Create a UTC datetime for testing."""
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+# Known dates:
+# 2026-02-16 = Monday, 2026-02-17 = Tuesday, 2026-02-21 = Saturday, 2026-02-22 = Sunday
+MONDAY_10AM = _dt(2026, 2, 16, 10)
+MONDAY_7AM = _dt(2026, 2, 16, 7)
+MONDAY_19PM = _dt(2026, 2, 16, 19)
+MONDAY_23PM = _dt(2026, 2, 16, 23)
+SATURDAY_14PM = _dt(2026, 2, 21, 14)
+SATURDAY_3AM = _dt(2026, 2, 21, 3)
+SUNDAY_10AM = _dt(2026, 2, 22, 10)
+SUNDAY_22PM = _dt(2026, 2, 22, 22)
+
+
+# ---------------------------------------------------------------------------
+# Construction & validation
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_defaults(self):
+        policy = TimeAwarePolicy()
+        assert policy.weekend_multiplier == 0.85
+        assert policy.offhour_multiplier == 0.90
+        assert policy.work_start == time(9, 0)
+        assert policy.work_end == time(18, 0)
+
+    def test_custom_params(self):
+        policy = TimeAwarePolicy(
+            weekend_multiplier=0.70,
+            offhour_multiplier=0.80,
+            work_start=time(8, 30),
+            work_end=time(17, 30),
+        )
+        assert policy.weekend_multiplier == 0.70
+        assert policy.offhour_multiplier == 0.80
+        assert policy.work_start == time(8, 30)
+        assert policy.work_end == time(17, 30)
+
+    def test_validates_weekend_multiplier_zero(self):
+        with pytest.raises(ValueError, match="weekend_multiplier"):
+            TimeAwarePolicy(weekend_multiplier=0.0)
+
+    def test_validates_weekend_multiplier_over_one(self):
+        with pytest.raises(ValueError, match="weekend_multiplier"):
+            TimeAwarePolicy(weekend_multiplier=1.5)
+
+    def test_validates_offhour_multiplier(self):
+        with pytest.raises(ValueError, match="offhour_multiplier"):
+            TimeAwarePolicy(offhour_multiplier=0.0)
+
+    def test_validates_work_hours_order(self):
+        with pytest.raises(ValueError, match="work_start.*before.*work_end"):
+            TimeAwarePolicy(work_start=time(18, 0), work_end=time(9, 0))
+
+    def test_validates_work_hours_equal(self):
+        with pytest.raises(ValueError, match="work_start.*before.*work_end"):
+            TimeAwarePolicy(work_start=time(9, 0), work_end=time(9, 0))
+
+
+# ---------------------------------------------------------------------------
+# get_multiplier: business hours
+# ---------------------------------------------------------------------------
+
+
+class TestBusinessHours:
+    def test_weekday_business_hours(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(MONDAY_10AM) == 1.0
+
+    def test_weekday_at_work_start(self):
+        policy = TimeAwarePolicy()
+        dt = _dt(2026, 2, 16, 9, 0)  # Monday 09:00
+        assert policy.get_multiplier(dt) == 1.0
+
+    def test_weekday_just_before_work_end(self):
+        policy = TimeAwarePolicy()
+        dt = _dt(2026, 2, 16, 17, 59)  # Monday 17:59
+        assert policy.get_multiplier(dt) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# get_multiplier: off-hours
+# ---------------------------------------------------------------------------
+
+
+class TestOffHours:
+    def test_weekday_before_work(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(MONDAY_7AM) == 0.90
+
+    def test_weekday_after_work(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(MONDAY_19PM) == 0.90
+
+    def test_weekday_at_work_end(self):
+        policy = TimeAwarePolicy()
+        dt = _dt(2026, 2, 16, 18, 0)  # Monday 18:00 = off-hours
+        assert policy.get_multiplier(dt) == 0.90
+
+    def test_weekday_late_night(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(MONDAY_23PM) == 0.90
+
+
+# ---------------------------------------------------------------------------
+# get_multiplier: weekends
+# ---------------------------------------------------------------------------
+
+
+class TestWeekend:
+    def test_saturday_business_hours(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(SATURDAY_14PM) == 0.85
+
+    def test_sunday_business_hours(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(SUNDAY_10AM) == 0.85
+
+
+# ---------------------------------------------------------------------------
+# get_multiplier: weekend + off-hours
+# ---------------------------------------------------------------------------
+
+
+class TestWeekendOffHours:
+    def test_saturday_offhour(self):
+        policy = TimeAwarePolicy()
+        # Weekend AND off-hours -> min(0.85, 0.90) = 0.85
+        assert policy.get_multiplier(SATURDAY_3AM) == 0.85
+
+    def test_sunday_offhour(self):
+        policy = TimeAwarePolicy()
+        assert policy.get_multiplier(SUNDAY_22PM) == 0.85
+
+    def test_weekend_offhour_custom_multipliers(self):
+        policy = TimeAwarePolicy(
+            weekend_multiplier=0.70, offhour_multiplier=0.60
+        )
+        # min(0.70, 0.60) = 0.60
+        assert policy.get_multiplier(SATURDAY_3AM) == 0.60
+
+
+# ---------------------------------------------------------------------------
+# evaluate()
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_business_hours_no_event(self):
+        policy = TimeAwarePolicy()
+        result = policy.evaluate(CTX, dt=MONDAY_10AM)
+        assert result.multiplier == 1.0
+        assert result.classification == "business_hours"
+        assert result.is_weekend is False
+        assert result.is_offhour is False
+        assert policy.get_events() == []
+
+    def test_offhour_records_event(self):
+        policy = TimeAwarePolicy()
+        result = policy.evaluate(CTX, dt=MONDAY_7AM)
+        assert result.multiplier == 0.90
+        assert result.classification == "offhour"
+        events = policy.get_events()
+        assert len(events) == 1
+        assert events[0].event_type == "TIME_POLICY_APPLIED"
+        assert events[0].decision == Decision.DEGRADE
+
+    def test_weekend_records_event(self):
+        policy = TimeAwarePolicy()
+        result = policy.evaluate(CTX, dt=SATURDAY_14PM)
+        assert result.multiplier == 0.85
+        assert result.classification == "weekend"
+        events = policy.get_events()
+        assert len(events) == 1
+        assert events[0].metadata["classification"] == "weekend"
+
+    def test_weekend_offhour_records_event(self):
+        policy = TimeAwarePolicy()
+        result = policy.evaluate(CTX, dt=SATURDAY_3AM)
+        assert result.classification == "weekend_offhour"
+        events = policy.get_events()
+        assert len(events) == 1
+        assert events[0].metadata["is_weekend"] is True
+        assert events[0].metadata["is_offhour"] is True
+
+    def test_event_has_request_id(self):
+        policy = TimeAwarePolicy()
+        policy.evaluate(CTX, dt=MONDAY_7AM)
+        assert policy.get_events()[0].request_id == "test-time"
+
+    def test_event_without_ctx(self):
+        policy = TimeAwarePolicy()
+        policy.evaluate(dt=MONDAY_7AM)
+        assert policy.get_events()[0].request_id is None
+
+    def test_event_metadata_fields(self):
+        policy = TimeAwarePolicy()
+        policy.evaluate(CTX, dt=MONDAY_7AM)
+        meta = policy.get_events()[0].metadata
+        assert "multiplier" in meta
+        assert "classification" in meta
+        assert "is_weekend" in meta
+        assert "is_offhour" in meta
+        assert "time" in meta
+        assert "weekday" in meta
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+
+class TestStateManagement:
+    def test_get_events_returns_copy(self):
+        policy = TimeAwarePolicy()
+        policy.evaluate(dt=MONDAY_7AM)
+        events1 = policy.get_events()
+        events2 = policy.get_events()
+        assert events1 is not events2
+
+    def test_clear_events(self):
+        policy = TimeAwarePolicy()
+        policy.evaluate(dt=MONDAY_7AM)
+        assert len(policy.get_events()) == 1
+        policy.clear_events()
+        assert len(policy.get_events()) == 0
+
+    def test_multiple_evaluations_accumulate(self):
+        policy = TimeAwarePolicy()
+        policy.evaluate(dt=MONDAY_7AM)
+        policy.evaluate(dt=SATURDAY_14PM)
+        assert len(policy.get_events()) == 2
+
+
+# ---------------------------------------------------------------------------
+# Custom work hours
+# ---------------------------------------------------------------------------
+
+
+class TestCustomWorkHours:
+    def test_early_start(self):
+        policy = TimeAwarePolicy(work_start=time(6, 0), work_end=time(15, 0))
+        dt = _dt(2026, 2, 16, 6, 0)  # Monday 06:00
+        assert policy.get_multiplier(dt) == 1.0
+
+    def test_late_end(self):
+        policy = TimeAwarePolicy(work_start=time(10, 0), work_end=time(22, 0))
+        dt = _dt(2026, 2, 16, 21, 59)  # Monday 21:59
+        assert policy.get_multiplier(dt) == 1.0
+
+    def test_narrow_window(self):
+        policy = TimeAwarePolicy(work_start=time(10, 0), work_end=time(12, 0))
+        # 09:59 = offhour
+        assert policy.get_multiplier(_dt(2026, 2, 16, 9, 59)) == 0.90
+        # 10:00 = business
+        assert policy.get_multiplier(_dt(2026, 2, 16, 10, 0)) == 1.0
+        # 11:59 = business
+        assert policy.get_multiplier(_dt(2026, 2, 16, 11, 59)) == 1.0
+        # 12:00 = offhour
+        assert policy.get_multiplier(_dt(2026, 2, 16, 12, 0)) == 0.90
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_evaluate(self):
+        policy = TimeAwarePolicy()
+        errors: list[Exception] = []
+
+        def evaluate_loop():
+            try:
+                for _ in range(50):
+                    policy.evaluate(dt=MONDAY_7AM)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=evaluate_loop) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert len(policy.get_events()) == 200  # 4 threads x 50
+
+
+# ---------------------------------------------------------------------------
+# Config round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRoundTrip:
+    def test_config_defaults(self):
+        from veronica_core.shield.config import TimeAwarePolicyConfig
+
+        cfg = TimeAwarePolicyConfig()
+        assert cfg.enabled is False
+        assert cfg.weekend_multiplier == 0.85
+        assert cfg.offhour_multiplier == 0.90
+        assert cfg.work_start_hour == 9
+        assert cfg.work_end_hour == 18
+
+    def test_shield_config_round_trip(self):
+        from veronica_core.shield.config import (
+            ShieldConfig,
+            TimeAwarePolicyConfig,
+        )
+
+        cfg = ShieldConfig(
+            time_aware_policy=TimeAwarePolicyConfig(
+                enabled=True,
+                weekend_multiplier=0.70,
+                offhour_multiplier=0.80,
+            )
+        )
+        d = cfg.to_dict()
+        restored = ShieldConfig.from_dict(d)
+        assert restored.time_aware_policy.enabled is True
+        assert restored.time_aware_policy.weekend_multiplier == 0.70
+        assert restored.time_aware_policy.offhour_multiplier == 0.80
+
+    def test_shield_config_is_any_enabled(self):
+        from veronica_core.shield.config import (
+            ShieldConfig,
+            TimeAwarePolicyConfig,
+        )
+
+        cfg = ShieldConfig(
+            time_aware_policy=TimeAwarePolicyConfig(enabled=True)
+        )
+        assert cfg.is_any_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# TimeResult
+# ---------------------------------------------------------------------------
+
+
+class TestTimeResult:
+    def test_result_fields(self):
+        result = TimeResult(
+            multiplier=0.85,
+            classification="weekend",
+            is_weekend=True,
+            is_offhour=False,
+        )
+        assert result.multiplier == 0.85
+        assert result.classification == "weekend"
+        assert result.is_weekend is True
+        assert result.is_offhour is False


### PR DESCRIPTION
## Summary
- New `TimeAwarePolicy`: reduces budget ceilings during weekends and off-hours
- Weekend (Sat/Sun): 0.85x multiplier (configurable)
- Off-hours (outside 09:00-18:00): 0.90x multiplier (configurable)
- Weekend + off-hours: min(weekend, offhour) multiplier
- Business hours: 1.0x (no reduction)
- `TimeAwarePolicyConfig` added to `ShieldConfig` (opt-in, disabled by default)
- `TIME_POLICY_APPLIED` SafetyEvent recorded when multiplier < 1.0
- 37 new tests covering all time classifications, custom work hours, thread safety, config

## Test plan
- [x] 37 unit tests passing
- [x] Full suite: 500 passed, 4 xfailed
- [x] No breaking changes to existing APIs