### PR TITLE
feat(shield): add direction lock to AdaptiveBudgetHook

### DIFF
--- a/src/veronica_core/shield/config.py
+++ b/src/veronica_core/shield/config.py
@@ -136,6 +136,7 @@ class AdaptiveBudgetConfig:
     max_step_pct: float = 0.05
     min_multiplier: float = 0.6
     max_multiplier: float = 1.2
+    direction_lock: bool = True
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- **Direction lock**: After tighten, blocks loosen until all exceeded (HALT) events clear from the rolling window
- Records `ADAPTIVE_DIRECTION_LOCKED` SafetyEvent when loosen is blocked
- `direction_lock=False` by default in constructor (backward compatible)
- `AdaptiveBudgetConfig.direction_lock=True` as recommended production default
- Does not block further tightening, only loosening

## Test plan
- [x] 81 adaptive budget tests passing (68 prior + 13 new)
- [x] 543 total tests passing, 0 regressions
- [x] Blocks loosen after tighten with events remaining
- [x] Allows loosen when exceeded events clear (window expiry)
- [x] No block without direction_lock enabled
- [x] Records ADAPTIVE_DIRECTION_LOCKED event with metadata
- [x] Does not change multiplier when locked
- [x] Allows further tighten when locked
- [x] Reset clears last_action
- [x] Config round-trip

Generated with [Claude Code](https://claude.com/claude-code)