### PR TITLE
feat: release quality gate (CI blocks update leaks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  release-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Release quality gate
+        run: python tools/release_check.py --mode=pr
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Release quality gate
+        run: python tools/release_check.py --mode=release --tag=${{ github.event.release.tag_name }}
+
       - name: Install build tools
         run: python -m pip install --upgrade pip build twine
 
@@ -27,6 +30,18 @@ jobs:
 
       - name: Check distribution
         run: twine check dist/*
+
+      - name: Dry-run install and verify version
+        run: |
+          pip install dist/*.whl
+          INSTALLED=$(python -c "import veronica_core; print(veronica_core.__version__)")
+          EXPECTED="${{ github.event.release.tag_name }}"
+          EXPECTED="${EXPECTED#v}"
+          echo "Installed: $INSTALLED, Expected: $EXPECTED"
+          if [ "$INSTALLED" != "$EXPECTED" ]; then
+            echo "::error::Version mismatch: installed=$INSTALLED expected=$EXPECTED"
+            exit 1
+          fi
 
       - name: Publish to PyPI
         if: "!contains(github.event.release.tag_name, 'rc')"

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -1,0 +1,59 @@
+"""Tests for tools/release_check.py -- release quality gate."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "tools" / "release_check.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+
+
+class TestPRMode:
+    def test_script_runs(self) -> None:
+        """Script executes without crashing."""
+        result = _run("--mode=pr")
+        # May pass or fail depending on repo state, but should not crash
+        assert result.returncode in (0, 1)
+        assert "Version Consistency" in result.stderr or "Version Consistency" in result.stdout
+
+    def test_checks_all_sections(self) -> None:
+        """All four check sections appear in output."""
+        result = _run("--mode=pr")
+        output = result.stdout + result.stderr
+        assert "A. Version Consistency" in output
+        assert "B. README Freshness" in output
+        assert "C. Exports Surface" in output
+        assert "D. Docs Link Reachability" in output
+
+    def test_results_summary(self) -> None:
+        """Results summary line is present."""
+        result = _run("--mode=pr")
+        output = result.stdout + result.stderr
+        assert "Results:" in output
+        assert "passed" in output
+
+
+class TestReleaseMode:
+    def test_release_mode_with_tag(self) -> None:
+        """Release mode accepts --tag argument."""
+        result = _run("--mode=release", "--tag=v0.7.0")
+        output = result.stdout + result.stderr
+        assert "Version Consistency" in output
+
+    def test_release_mode_wrong_tag(self) -> None:
+        """Release mode fails on mismatched tag."""
+        result = _run("--mode=release", "--tag=v99.99.99")
+        output = result.stdout + result.stderr
+        assert "FAIL" in output
+        assert result.returncode == 1

--- a/tools/release_check.py
+++ b/tools/release_check.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Release quality gate -- fails CI when update leaks are detected.
+
+Checks:
+  A. Version consistency (pyproject.toml vs __init__.py vs git tag)
+  B. README update freshness (ship readiness, docs links, demo links)
+  C. Exports surface (public API symbols in __init__.py)
+  D. Docs link reachability (README references existing files)
+
+Usage:
+  python tools/release_check.py --mode=pr       # push / PR checks
+  python tools/release_check.py --mode=release --tag=v0.7.0  # release checks
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+CORE_INIT = ROOT / "src" / "veronica_core" / "__init__.py"
+SHIELD_INIT = ROOT / "src" / "veronica_core" / "shield" / "__init__.py"
+README = ROOT / "README.md"
+
+
+class CheckResult:
+    """Accumulates pass/fail results with messages."""
+
+    def __init__(self) -> None:
+        self.passed: list[str] = []
+        self.failed: list[str] = []
+
+    def ok(self, msg: str) -> None:
+        self.passed.append(msg)
+        print(f"  [PASS] {msg}")
+
+    def fail(self, msg: str) -> None:
+        self.failed.append(msg)
+        print(f"  [FAIL] {msg}")
+
+    @property
+    def success(self) -> bool:
+        return len(self.failed) == 0
+
+
+def _extract_version_pyproject() -> str | None:
+    """Extract version from pyproject.toml."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _extract_version_init(path: Path) -> str | None:
+    """Extract __version__ from a Python __init__.py."""
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def check_version_consistency(result: CheckResult, tag: str | None) -> None:
+    """A. Version consistency."""
+    print("\n--- A. Version Consistency ---")
+
+    pyproject_ver = _extract_version_pyproject()
+    init_ver = _extract_version_init(CORE_INIT)
+
+    if pyproject_ver is None:
+        result.fail("Cannot parse version from pyproject.toml")
+        return
+
+    result.ok(f"pyproject.toml: {pyproject_ver}")
+
+    if init_ver is None:
+        result.fail("Cannot parse __version__ from veronica_core/__init__.py")
+    elif init_ver != pyproject_ver:
+        result.fail(
+            f"veronica_core/__init__.py ({init_ver}) "
+            f"!= pyproject.toml ({pyproject_ver})"
+        )
+    else:
+        result.ok(f"veronica_core/__init__.py: {init_ver}")
+
+    if tag is not None:
+        tag_ver = tag.lstrip("v")
+        if tag_ver != pyproject_ver:
+            result.fail(
+                f"Git tag ({tag_ver}) != pyproject.toml ({pyproject_ver})"
+            )
+        else:
+            result.ok(f"Git tag: {tag_ver}")
+
+
+def check_readme_freshness(result: CheckResult) -> None:
+    """B. README update freshness."""
+    print("\n--- B. README Freshness ---")
+
+    if not README.exists():
+        result.fail("README.md not found")
+        return
+
+    text = README.read_text(encoding="utf-8")
+
+    # Ship Readiness section exists
+    if re.search(r"Ship Readiness", text):
+        result.ok("Ship Readiness section found")
+    else:
+        result.fail("Ship Readiness section missing from README")
+
+    # Link to adaptive-control.md
+    if "docs/adaptive-control.md" in text:
+        result.ok("Link to docs/adaptive-control.md found")
+    else:
+        result.fail("Link to docs/adaptive-control.md missing from README")
+
+    # Link to adaptive_demo.py
+    if "adaptive_demo.py" in text:
+        result.ok("Reference to adaptive_demo.py found")
+    else:
+        result.fail("Reference to adaptive_demo.py missing from README")
+
+    # Version string in Ship Readiness matches pyproject
+    pyproject_ver = _extract_version_pyproject()
+    if pyproject_ver:
+        pattern = rf"Ship Readiness.*v{re.escape(pyproject_ver)}"
+        if re.search(pattern, text):
+            result.ok(
+                f"Ship Readiness references v{pyproject_ver}"
+            )
+        else:
+            result.fail(
+                f"Ship Readiness does not reference v{pyproject_ver}"
+            )
+
+
+def check_exports(result: CheckResult) -> None:
+    """C. Public API surface check."""
+    print("\n--- C. Exports Surface ---")
+
+    required_in_shield = [
+        "AdaptiveBudgetHook",
+        "AdjustmentResult",
+        "TimeAwarePolicy",
+        "SafetyEvent",
+        "TokenBudgetHook",
+        "BudgetWindowHook",
+        "InputCompressionHook",
+    ]
+
+    required_in_core = [
+        "AdaptiveBudgetHook",
+        "TimeAwarePolicy",
+        "TokenBudgetHook",
+        "BudgetWindowHook",
+        "InputCompressionHook",
+        "ShieldConfig",
+    ]
+
+    # Check shield/__init__.py
+    if not SHIELD_INIT.exists():
+        result.fail("shield/__init__.py not found")
+        return
+
+    shield_text = SHIELD_INIT.read_text(encoding="utf-8")
+    for sym in required_in_shield:
+        if sym in shield_text:
+            result.ok(f"shield exports {sym}")
+        else:
+            result.fail(f"shield missing export: {sym}")
+
+    # Check veronica_core/__init__.py
+    if not CORE_INIT.exists():
+        result.fail("veronica_core/__init__.py not found")
+        return
+
+    core_text = CORE_INIT.read_text(encoding="utf-8")
+    for sym in required_in_core:
+        if sym in core_text:
+            result.ok(f"veronica_core exports {sym}")
+        else:
+            result.fail(f"veronica_core missing export: {sym}")
+
+
+def check_docs_links(result: CheckResult) -> None:
+    """D. Docs file reachability."""
+    print("\n--- D. Docs Link Reachability ---")
+
+    if not README.exists():
+        result.fail("README.md not found")
+        return
+
+    text = README.read_text(encoding="utf-8")
+
+    # Find all relative links in README (markdown links)
+    links = re.findall(r'\[.*?\]\(((?!http)[^)]+)\)', text)
+
+    if not links:
+        result.ok("No relative links to check")
+        return
+
+    for link in links:
+        # Strip anchor fragments
+        path_str = link.split("#")[0]
+        if not path_str:
+            continue
+        target = ROOT / path_str
+        if target.exists():
+            result.ok(f"Link target exists: {path_str}")
+        else:
+            result.fail(f"Link target missing: {path_str}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Release quality gate")
+    parser.add_argument(
+        "--mode",
+        choices=["pr", "release"],
+        default="pr",
+        help="Check mode: pr (push/PR) or release (with tag)",
+    )
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help="Git tag to verify (release mode only)",
+    )
+    args = parser.parse_args()
+
+    tag = args.tag if args.mode == "release" else None
+
+    result = CheckResult()
+
+    check_version_consistency(result, tag)
+    check_readme_freshness(result)
+    check_exports(result)
+    check_docs_links(result)
+
+    print(f"\n{'='*50}")
+    print(
+        f"Results: {len(result.passed)} passed, "
+        f"{len(result.failed)} failed"
+    )
+
+    if result.failed:
+        print("\nFailed checks:")
+        for msg in result.failed:
+            print(f"  - {msg}")
+        print("\nRelease check FAILED.")
+        return 1
+
+    print("\nRelease check PASSED.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `tools/release_check.py` with 4 automated checks (version, README, exports, docs links)
- Add `release-check` job to CI (runs on every push/PR, blocks merge on failure)
- Add release-mode check + dry-run install to publish workflow
- 5 new tests for the script. 585 total passing.

## What it catches
- `__init__.py __version__` out of sync with `pyproject.toml` (currently failing: 0.6.0 vs 0.7.0)
- Missing Ship Readiness section or version mismatch in README
- Public API symbols missing from `__init__.py` exports
- Broken relative links in README (docs/examples)
- Git tag vs pyproject version mismatch on release

## Test plan
- [x] `python tools/release_check.py --mode=pr` detects current `__version__` leak
- [x] `--mode=release --tag=v99.99.99` correctly fails on wrong tag
- [x] 5 dedicated tests pass
- [x] 585 total tests passing