### PR TITLE
chore: replace PR template with release checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,77 +1,15 @@
-# Pull Request
+## Summary
+<!-- 1-3 bullet points describing the change -->
 
-## Description
-<!-- Provide a clear and concise description of what this PR does -->
+## Release checklist
+<!-- Check all that apply. CI enforces version + exports + README via tools/release_check.py -->
 
-Fixes # (issue number)
+- [ ] Version bump: `pyproject.toml` and `src/veronica_core/__init__.py` match
+- [ ] README: Ship Readiness section references current version
+- [ ] Docs: new features documented (or existing docs updated)
+- [ ] Examples: at least one demo updated or added
+- [ ] Exports: public API symbols in `__init__.py` files
+- [ ] `python tools/release_check.py --mode=pr` passes locally
 
-## Type of change
-<!-- Check all that apply -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Code refactoring
-- [ ] Test coverage improvement
-
-## Changes made
-<!-- List the key changes in this PR -->
--
--
--
-
-## Testing
-<!-- Describe the tests you ran to verify your changes -->
-- [ ] All existing tests pass (`pytest`)
-- [ ] New tests added for new functionality
-- [ ] Manual testing performed
-
-**Test commands run:**
-```bash
-pytest tests/
-python examples/basic_usage.py
-python proof_runner.py
-```
-
-**Test results:**
-```
-# Paste relevant test output here
-```
-
-## Documentation
-<!-- Check all that apply -->
-- [ ] Updated README.md
-- [ ] Updated API.md
-- [ ] Updated CHANGELOG.md
-- [ ] Added/updated docstrings
-- [ ] Added/updated examples
-
-## Checklist
-<!-- Ensure all items are checked before requesting review -->
-- [ ] My code follows the project's coding standards
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published
-
-## Breaking Changes
-<!-- If this is a breaking change, describe migration path for users -->
-**Old API:**
-```python
-# Code using old API
-```
-
-**New API:**
-```python
-# Code using new API
-```
-
-**Migration guide:**
-<!-- Explain how users should update their code -->
-
-## Additional context
-<!-- Add any other context, screenshots, or performance benchmarks -->
+## Test plan
+<!-- How was this tested? -->


### PR DESCRIPTION
## Summary
- Replace verbose 77-line PR template with focused 15-line release checklist
- Checklist mirrors `tools/release_check.py` checks (version, README, docs, exports)
- Human checklist as defense-in-depth; CI is the real gate

## Test plan
- [x] Template file renders correctly on GitHub
- [x] No code changes, no test impact