### PR TITLE
fix: sync __version__ to 0.7.0 (caught by release gate)

### DIFF
--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -1,6 +1,6 @@
 """VERONICA Core - Failsafe state machine for mission-critical applications."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 # Core state machine
 from veronica_core.state import (


### PR DESCRIPTION
## Summary
- Fix `src/veronica_core/__init__.py` __version__: `0.6.0` -> `0.7.0`
- This is the exact leak that `tools/release_check.py` (PR #35) was built to catch

## Test plan
- [x] `python tools/release_check.py --mode=pr` now passes (22/22)
- [x] 585 tests still passing