### PR TITLE
fix: address review findings from code audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=veronica --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -v
+          pytest --cov=veronica_core --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.12"
 
       - name: Release quality gate
-        run: python tools/release_check.py --mode=release --tag=${{ github.event.release.tag_name }}
+        run: python tools/release_check.py --mode=release "--tag=${{ github.event.release.tag_name }}"
 
       - name: Install build tools
         run: python -m pip install --upgrade pip build twine
@@ -33,7 +33,7 @@ jobs:
 
       - name: Dry-run install and verify version
         run: |
-          pip install dist/*.whl
+          pip install dist/veronica_core-*.whl
           INSTALLED=$(python -c "import veronica_core; print(veronica_core.__version__)")
           EXPECTED="${{ github.event.release.tag_name }}"
           EXPECTED="${EXPECTED#v}"
@@ -44,14 +44,14 @@ jobs:
           fi
 
       - name: Publish to PyPI
-        if: "!contains(github.event.release.tag_name, 'rc')"
+        if: ${{ !contains(github.event.release.tag_name, 'rc') && !contains(github.event.release.tag_name, 'alpha') && !contains(github.event.release.tag_name, 'beta') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
 
       - name: Publish to TestPyPI (release candidates)
-        if: contains(github.event.release.tag_name, 'rc')
+        if: ${{ contains(github.event.release.tag_name, 'rc') || contains(github.event.release.tag_name, 'alpha') || contains(github.event.release.tag_name, 'beta') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ testpaths = ["tests"]
 pythonpath = ["src"]
 
 [tool.coverage.run]
-source = ["veronica"]
+source = ["veronica_core"]
 
 [tool.coverage.report]
 fail_under = 90

--- a/src/veronica_core/shield/adaptive_budget.py
+++ b/src/veronica_core/shield/adaptive_budget.py
@@ -81,7 +81,8 @@ class AdaptiveBudgetHook:
       - >= tighten_trigger HALT events in window  -> tighten by tighten_pct
       - 0 DEGRADE events in window                -> loosen by loosen_pct
       - Otherwise                                  -> hold (no change)
-      - Multiplier clamped to [1 - max_adjustment, 1 + max_adjustment]
+      - Multiplier clamped to [min_multiplier, max_multiplier]
+        (defaults computed from max_adjustment if not explicitly set)
     """
 
     def __init__(
@@ -591,12 +592,17 @@ class AdaptiveBudgetHook:
     # -- Event access --------------------------------------------------------
 
     def get_events(self) -> list[SafetyEvent]:
-        """Return accumulated ADAPTIVE_ADJUSTMENT events (shallow copy)."""
+        """Return all accumulated safety events (shallow copy).
+
+        Includes ADAPTIVE_ADJUSTMENT, ADAPTIVE_COOLDOWN_BLOCKED,
+        ADAPTIVE_DIRECTION_LOCKED, ANOMALY_TIGHTENING_APPLIED,
+        and ANOMALY_RECOVERED events.
+        """
         with self._lock:
             return list(self._safety_events)
 
     def clear_events(self) -> None:
-        """Clear accumulated ADAPTIVE_ADJUSTMENT events."""
+        """Clear all accumulated safety events."""
         with self._lock:
             self._safety_events.clear()
 

--- a/tools/release_check.py
+++ b/tools/release_check.py
@@ -48,6 +48,8 @@ class CheckResult:
 
 def _extract_version_pyproject() -> str | None:
     """Extract version from pyproject.toml."""
+    if not PYPROJECT.exists():
+        return None
     text = PYPROJECT.read_text(encoding="utf-8")
     match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
     return match.group(1) if match else None
@@ -127,7 +129,7 @@ def check_readme_freshness(result: CheckResult) -> None:
     pyproject_ver = _extract_version_pyproject()
     if pyproject_ver:
         pattern = rf"Ship Readiness.*v{re.escape(pyproject_ver)}"
-        if re.search(pattern, text):
+        if re.search(pattern, text, re.DOTALL):
             result.ok(
                 f"Ship Readiness references v{pyproject_ver}"
             )
@@ -230,6 +232,9 @@ def main() -> int:
     args = parser.parse_args()
 
     tag = args.tag if args.mode == "release" else None
+
+    if args.mode == "release" and tag is None:
+        print("WARNING: --mode=release without --tag; tag check will be skipped")
 
     result = CheckResult()
 


### PR DESCRIPTION
## Summary
- Fix shell injection in publish.yml (unquoted tag expansion)
- Fix CI coverage measuring wrong package (`veronica` -> `veronica_core`)
- Fix `from_dict()` crash on unknown keys and None sub-dicts (forward compat)
- Fix all README code examples using legacy `veronica.*` imports
- Fix inaccurate docstrings in AdaptiveBudgetHook
- Harden release_check.py (FileNotFoundError guard, DOTALL regex)
- Add 4 new tests (589 total, was 585)

## Release checklist
- [x] Version bump: `pyproject.toml` and `src/veronica_core/__init__.py` match
- [x] README: Ship Readiness section references current version
- [x] Exports: public API symbols in `__init__.py` files
- [x] `python tools/release_check.py --mode=pr` passes locally

## Test plan
- `pytest tests/ -q` -> 589 passed, 4 xfailed
- `python tools/release_check.py --mode=pr` -> 22 passed, 0 failed
- Verified `from_dict()` handles unknown keys and None sub-dicts
- Verified publish.yml tag quoting with special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)