### PR TITLE
docs(readme): sync Ship Readiness test count (590)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ See [docs/adaptive-control.md](docs/adaptive-control.md) for the full event refe
 - [x] PyPI auto-publish on GitHub Release
 - [x] Everything is opt-in & non-breaking (default behavior unchanged)
 
-589 tests passing. Minimum production use-case: runaway containment + graceful degrade + auditable events + token budgets + input compression + adaptive ceiling + time-aware scheduling + anomaly detection.
+590 tests passing. Minimum production use-case: runaway containment + graceful degrade + auditable events + token budgets + input compression + adaptive ceiling + time-aware scheduling + anomaly detection.
 
 ---
 
@@ -382,7 +382,7 @@ pip install -e ".[dev]"
 pytest
 ```
 
-![CI](https://img.shields.io/badge/tests-589%20passing-brightgreen)
+![CI](https://img.shields.io/badge/tests-590%20passing-brightgreen)
 ![Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
 


### PR DESCRIPTION
## Summary
- Update test count 589 -> 590 in Ship Readiness section and CI badge

## Test plan
- [x] release_check 29/29 PASS
- [x] 590 tests passing