### PR TITLE
ci: disable upload step for rc pipeline verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,14 +46,14 @@ jobs:
           fi
 
       - name: Publish to PyPI
-        if: ${{ !contains(github.event.release.tag_name, 'rc') && !contains(github.event.release.tag_name, 'alpha') && !contains(github.event.release.tag_name, 'beta') }}
+        if: false  # temporarily disabled for rc pipeline verification
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
 
       - name: Publish to TestPyPI (release candidates)
-        if: ${{ contains(github.event.release.tag_name, 'rc') || contains(github.event.release.tag_name, 'alpha') || contains(github.event.release.tag_name, 'beta') }}
+        if: false  # temporarily disabled for rc pipeline verification
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Temporarily disable PyPI and TestPyPI upload steps (`if: false`)
- Allows rc tag to verify build/check/install pipeline without upload credentials
- Will be reverted after verification

## Test plan
- [ ] Create `v0.7.0-rc.2` prerelease after merge
- [ ] Verify all steps up to upload pass (release_check, build, twine check, dry-run install)