### PR TITLE
ci: re-enable PyPI upload step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,14 +46,14 @@ jobs:
           fi
 
       - name: Publish to PyPI
-        if: false  # temporarily disabled for rc pipeline verification
+        if: ${{ !contains(github.event.release.tag_name, 'rc') && !contains(github.event.release.tag_name, 'alpha') && !contains(github.event.release.tag_name, 'beta') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
 
       - name: Publish to TestPyPI (release candidates)
-        if: false  # temporarily disabled for rc pipeline verification
+        if: ${{ contains(github.event.release.tag_name, 'rc') || contains(github.event.release.tag_name, 'alpha') || contains(github.event.release.tag_name, 'beta') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Restore PyPI and TestPyPI upload conditions after successful rc pipeline verification
- v0.7.0-rc.2 confirmed all pre-upload steps pass (release_check, build, twine check, dry-run install)

## Verified
- PR #43 disabled uploads, v0.7.0-rc.2 workflow run 22163952669: all green