### PR TITLE
release: v0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [docs/adaptive-control.md](docs/adaptive-control.md) for the full event refe
 
 ---
 
-## Ship Readiness (v0.7.0)
+## Ship Readiness (v0.7.1)
 
 - [x] BudgetWindow stops runaway execution (ceiling enforced)
 - [x] SafetyEvent records structured evidence for non-ALLOW decisions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "veronica-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Enforcement hooks for LLM agent runs. Budget limits, concurrency gating, and degradation control."
 readme = "README.md"
 license = "MIT"

--- a/src/veronica_core/__init__.py
+++ b/src/veronica_core/__init__.py
@@ -1,6 +1,6 @@
 """VERONICA Core - Failsafe state machine for mission-critical applications."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 # Core state machine
 from veronica_core.state import (

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -47,7 +47,7 @@ class TestPRMode:
 class TestReleaseMode:
     def test_release_mode_with_tag(self) -> None:
         """Release mode accepts --tag argument."""
-        result = _run("--mode=release", "--tag=v0.7.0")
+        result = _run("--mode=release", "--tag=v0.7.1")
         output = result.stdout + result.stderr
         assert "Version Consistency" in output
 


### PR DESCRIPTION
## Summary
- Version bump 0.7.0 -> 0.7.1 for PyPI production publish
- pyproject.toml, __init__.py, README Ship Readiness, test assertion updated

## Verification
- release_check --mode=release --tag=v0.7.1: 30/30 PASS
- pytest: 590 passed, 4 xfailed
- rc.2 pipeline verification: all pre-upload steps green (run 22163952669)