### PR TITLE
docs(readme): add install header, data policy note, and navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # VERONICA
 
+```bash
+pip install veronica-core
+```
+
+Jump to [Quickstart (5 minutes)](#quickstart-5-minutes) or browse [docs/cookbook.md](docs/cookbook.md).
+
 ## LLM agents don't fail because of prompts. They fail because nothing stops them.
 
 You don't lose money because your model hallucinated.
@@ -149,8 +155,12 @@ See [docs/adaptive-control.md](docs/adaptive-control.md) for the full event refe
 - [examples/token_budget_minimal_demo.py](examples/token_budget_minimal_demo.py) -- token ceiling + minimal response
 - [examples/budget_degrade_demo.py](examples/budget_degrade_demo.py) -- call ceiling + model fallback
 - [examples/input_compression_skeleton_demo.py](examples/input_compression_skeleton_demo.py) -- input compression
+- [CHANGELOG.md](CHANGELOG.md) -- version history
 
 ---
+
+**Learns:** execution control patterns from SafetyEvents (budgets, degrade thresholds, time policy).
+**Never stores:** prompt contents. Evidence uses SHA-256 hashes by default.
 
 ## Ship Readiness (v0.7.1)
 


### PR DESCRIPTION
## Summary
- Top of README: `pip install veronica-core` + jump links to Quickstart and cookbook
- Before Ship Readiness: data policy statement (learns patterns, never stores prompts)
- What to read next: added CHANGELOG.md link

## Changes
- README.md only (+10 lines, 0 deletions from existing content)

## Test plan
- [x] release_check 32/32 PASS
- [x] pytest 590 passed
- [x] No existing content removed